### PR TITLE
macOS preferences text without Windows/Linux references

### DIFF
--- a/qml/Settings.qml
+++ b/qml/Settings.qml
@@ -537,7 +537,7 @@ Item {
 
                 visible: isDesktop // && (settingsManager.systray && element_worker.visible)
 
-                text: qsTr("Theengs will remain active in the system tray, and will wake up at a regular interval to refresh sensor data.")
+                text: (Qt.platform.os !== "osx") ? qsTr("Theengs will remain active in the system tray, and will wake up at a regular interval to refresh sensor data.") : qsTr("Theengs will refresh sensor data at a regular interval.")
                 textFormat: Text.PlainText
                 wrapMode: Text.WordWrap
                 color: Theme.colorSubText


### PR DESCRIPTION
Background updates explanation text to not reference Windows/Linux specific **system tray**

Before
<img width="1201" alt="Screenshot 2022-06-24 at 17 20 53" src="https://user-images.githubusercontent.com/17110652/175566557-f871a85a-de85-449d-b02a-6047b1fcf59a.png">

After
<img width="1202" alt="Screenshot 2022-06-24 at 17 20 22" src="https://user-images.githubusercontent.com/17110652/175566603-b59ce9cd-a6c8-4ccd-8d4b-aa2c837df4d3.png">

While this should still work fine with the original text on Windows/Linux, it might be good for one of you to quickly verify with

https://github.com/theengs/app/actions/runs/2556481838

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/theengs/app/blob/development/docs/participate/development.md#developer-certificate-of-origin).
