### PR TITLE
Correct abbreviation  for minutes in settings

### DIFF
--- a/qml/Settings.qml
+++ b/qml/Settings.qml
@@ -597,7 +597,7 @@ Item {
 
                     enabled: (settingsManager.systray && element_worker.visible)
 
-                    legend: " " + qsTr("m.", "short for minutes")
+                    legend: " " + qsTr("min", "short for minutes")
                     from: 5
                     to: 360
                     stepSize: 5


### PR DESCRIPTION
Correct abbreviation  for minutes in settings

I know this is a fine detail, and I'm sure no user would think the Update Interval setting shows a certain amount of metres, but being an application which in the widgets shows mainly scientific data for sensors I think it would be good form to also have the correct units displaying in other parts of the app.

**Before**
<img width="1201" alt="minutesOLD" src="https://user-images.githubusercontent.com/17110652/175574649-c6d8e71c-d6ce-48c1-a4f0-496dca1e1f17.png">

**After**
<img width="1201" alt="minutesNEW" src="https://user-images.githubusercontent.com/17110652/175574781-54ca56d8-efa5-4444-94d2-397b73132c53.png">

Fine on macOS even with the maximum interval setting of 360 min, but needs checking on all other platforms, if it might not require a wider selection box, or possibly even just the number in it and a changed text label like "Update interval in min/minutes"

https://github.com/theengs/app/actions/runs/2556733375

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/theengs/app/blob/development/docs/participate/development.md#developer-certificate-of-origin).
