### PR TITLE
12/24 hour clock

### DIFF
--- a/qml/Settings.qml
+++ b/qml/Settings.qml
@@ -268,7 +268,7 @@ Item {
                 bottomPadding: isMobile ? 12 : 0
                 visible: element_appThemeAuto.visible
 
-                text: qsTr("Dark mode will switch on automatically between 9 PM and 9 AM.")
+                text: (settingsManager.tempUnit === "C") ? qsTr("Dark mode will automatically be active between 21:00 and 9:00.") : qsTr("Dark mode will automatically be active between 9 PM and 9 AM.")
                 textFormat: Text.PlainText
                 wrapMode: Text.WordWrap
                 color: Theme.colorSubText


### PR DESCRIPTION
Using 12 or 24 hour clock in the preferences text about Dark Mode.

While this ideally would be set by the localised device settings the app is running on, with multi-platform I'm not sure how easy this would be in Qt.

I think we can very safely assume though that if a user selects the Metric unit system they are also familiar, and more importantly, more happy with a 24 time display, while Imperial users, mainly in the US I suppose, will prefer the AM/PM time indication.
Also slightly changed the actual text.


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/theengs/app/blob/development/docs/participate/development.md#developer-certificate-of-origin).
