### PR TITLE
Device IDs adjustment

### DIFF
--- a/src/devices/device_hygrotemp_cgd1.cpp
+++ b/src/devices/device_hygrotemp_cgd1.cpp
@@ -111,12 +111,11 @@ void DeviceHygrotempCGD1::parseAdvertisementData(const uint16_t adv_mode,
         float humi = -99.f;
 
         // get data
-        if ((data[0] == 0x88 && data[1] == 0x16) || // CGG1
-            (data[0] == 0x08 && data[1] == 0x07) || // CGG1
-            (data[0] == 0x88 && data[1] == 0x10) || // CGDK2
-            (data[0] == 0x08 && data[1] == 0x10) || // CGDK2
-            (data[0] == 0x08 && data[1] == 0x09) || // CGP1W
-            (data[0] == 0x08 && data[1] == 0x0c))   // CGD1
+        if (data[1] == 0x16 || // CGG1
+            data[1] == 0x07 || // CGG1
+            data[1] == 0x10 || // CGDK2
+            data[1] == 0x09 || // CGP1W
+            data[1] == 0x0c)   // CGD1
         {
             temp = static_cast<int32_t>(data[10] + (data[11] << 8)) / 10.f;
             if (temp != m_temperature)

--- a/src/devices/device_hygrotemp_cgdk2.cpp
+++ b/src/devices/device_hygrotemp_cgdk2.cpp
@@ -279,12 +279,11 @@ void DeviceHygrotempCGDK2::parseAdvertisementData(const uint16_t adv_mode,
         float humi = -99.f;
 
         // get data
-        if ((data[0] == 0x88 && data[1] == 0x16) || // CGG1
-            (data[0] == 0x08 && data[1] == 0x07) || // CGG1
-            (data[0] == 0x88 && data[1] == 0x10) || // CGDK2
-            (data[0] == 0x08 && data[1] == 0x10) || // CGDK2
-            (data[0] == 0x08 && data[1] == 0x09) || // CGP1W
-            (data[0] == 0x08 && data[1] == 0x0c))   // CGD1
+        if (data[1] == 0x16 || // CGG1
+            data[1] == 0x07 || // CGG1
+            data[1] == 0x10 || // CGDK2
+            data[1] == 0x09 || // CGP1W
+            data[1] == 0x0c)   // CGD1
         {
             temp = static_cast<int16_t>(data[10] + (data[11] << 8)) / 10.f;
             if (temp != m_temperature)

--- a/src/devices/device_hygrotemp_cgg1.cpp
+++ b/src/devices/device_hygrotemp_cgg1.cpp
@@ -320,12 +320,11 @@ void DeviceHygrotempCGG1::parseAdvertisementData(const uint16_t adv_mode,
         float humi = -99.f;
 
         // get data
-        if ((data[0] == 0x88 && data[1] == 0x16) || // CGG1
-            (data[0] == 0x08 && data[1] == 0x07) || // CGG1
-            (data[0] == 0x88 && data[1] == 0x10) || // CGDK2
-            (data[0] == 0x08 && data[1] == 0x10) || // CGDK2
-            (data[0] == 0x08 && data[1] == 0x09) || // CGD1
-            (data[0] == 0x08 && data[1] == 0x0c))   // CGP1W
+        if (data[1] == 0x16 || // CGG1
+            data[1] == 0x07 || // CGG1
+            data[1] == 0x10 || // CGDK2
+            data[1] == 0x09 || // CGP1W
+            data[1] == 0x0c)   // CGD1
         {
             temp = static_cast<int16_t>(data[10] + (data[11] << 8)) / 10.f;
             if (temp != m_temperature)

--- a/src/devices/device_hygrotemp_cgp1w.cpp
+++ b/src/devices/device_hygrotemp_cgp1w.cpp
@@ -111,12 +111,11 @@ void DeviceHygrotempCGP1W::parseAdvertisementData(const uint16_t adv_mode,
         int pres = -99.f;
 
         // get data
-        if ((data[0] == 0x88 && data[1] == 0x16) || // CGG1
-            (data[0] == 0x08 && data[1] == 0x07) || // CGG1
-            (data[0] == 0x88 && data[1] == 0x10) || // CGDK2
-            (data[0] == 0x08 && data[1] == 0x10) || // CGDK2
-            (data[0] == 0x08 && data[1] == 0x09) || // CGP1W
-            (data[0] == 0x08 && data[1] == 0x0c))   // CGD1
+        if (data[1] == 0x16 || // CGG1
+            data[1] == 0x07 || // CGG1
+            data[1] == 0x10 || // CGDK2
+            data[1] == 0x09 || // CGP1W
+            data[1] == 0x0c)   // CGD1
         {
             temp = static_cast<int16_t>(data[10] + (data[11] << 8)) / 10.f;
             if (temp != m_temperature)


### PR DESCRIPTION
Adjusting device IDs for CGG1, CGDK2, CGP1W and CGD1 to correctly only use the second byte.

As described in https://github.com/theengs/app/issues/56

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/theengs/app/blob/development/docs/participate/development.md#developer-certificate-of-origin).
