### PR TITLE
Android: foreground BLE-scan service to survive screen-off

### DIFF
--- a/assets/android/AndroidManifest.xml
+++ b/assets/android/AndroidManifest.xml
@@ -17,6 +17,13 @@
     <!-- Service -->
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" android:minSdkVersion="29" />
+    <!-- Foreground-service permissions so the BLE-scan service can keep scanning
+         past the screen-off cliff. FOREGROUND_SERVICE is required since API 28;
+         the typed FOREGROUND_SERVICE_CONNECTED_DEVICE is required since API 34
+         for BLE / companion-device services. Without these, startForegroundService()
+         throws SecurityException and the service never runs. -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" android:minSdkVersion="34" />
 
     <!-- MQTT -->
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
@@ -64,7 +71,8 @@
             </intent-filter>
         </receiver>
 
-        <service android:process=":qt_service" android:name=".TheengsAndroidService">
+        <service android:process=":qt_service" android:name=".TheengsAndroidService"
+                 android:foregroundServiceType="connectedDevice">
             <meta-data android:name="android.app.background_running" android:value="true" />
             <meta-data android:name="android.app.lib_name" android:value="-- %%INSERT_APP_LIB_NAME%% --" />
             <meta-data android:name="android.app.arguments" android:value="--service" />

--- a/assets/android/src/com/theengs/app/TheengsAndroidService.java
+++ b/assets/android/src/com/theengs/app/TheengsAndroidService.java
@@ -19,16 +19,26 @@
 package com.theengs.app;
 
 import java.lang.String;
-import android.util.Log;
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.content.BroadcastReceiver;
+import android.content.pm.ServiceInfo;
+import android.os.Build;
+import android.util.Log;
 
 import org.qtproject.qt.android.bindings.QtService;
 
 public class TheengsAndroidService extends QtService {
 
     private static final String TAG = "TheengsAndroidService";
+    // Foreground-service notification id + channel. Fixed per-process so
+    // startForeground/stopForeground refer to the same notification.
+    private static final int NOTIFICATION_ID = 1001;
+    private static final String CHANNEL_ID = "TheengsForegroundService";
 
     @Override
     public void onCreate() {
@@ -45,14 +55,80 @@ public class TheengsAndroidService extends QtService {
 
     @Override
     public void onDestroy() {
+        // Clear the foreground notification on stopService() so it doesn't
+        // linger in the tray after the user toggles off background scanning.
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                stopForeground(STOP_FOREGROUND_REMOVE);
+            } else {
+                stopForeground(true);
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "stopForeground failed", e);
+        }
         super.onDestroy();
     }
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
+        // Promote to foreground BEFORE delegating to QtService. Android
+        // ANRs / kills the service if startForeground() isn't called
+        // within 5 s of startForegroundService(). Typed as
+        // FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE because the service
+        // exists to keep BLE scan callbacks alive while the screen is off.
+        startInForeground();
         int ret = super.onStartCommand(intent, flags, startId);
-
         return START_STICKY;
+    }
+
+    private void startInForeground() {
+        try {
+            Notification notification = buildNotification();
+            if (Build.VERSION.SDK_INT >= 34) {
+                startForeground(
+                    NOTIFICATION_ID,
+                    notification,
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE
+                );
+            } else {
+                startForeground(NOTIFICATION_ID, notification);
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "startForeground failed", e);
+        }
+    }
+
+    private Notification buildNotification() {
+        NotificationManager nm =
+            (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationChannel ch = new NotificationChannel(
+                CHANNEL_ID,
+                "Theengs background service",
+                NotificationManager.IMPORTANCE_LOW
+            );
+            ch.setDescription("Keeps the BLE scan running while the app is in the background");
+            nm.createNotificationChannel(ch);
+        }
+        Intent launch =
+            getPackageManager().getLaunchIntentForPackage(getPackageName());
+        PendingIntent pi = PendingIntent.getActivity(
+            this, 0, launch,
+            PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE
+        );
+        Notification.Builder b;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            b = new Notification.Builder(this, CHANNEL_ID);
+        } else {
+            b = new Notification.Builder(this);
+        }
+        b.setSmallIcon(R.drawable.ic_stat_logo)
+         .setContentTitle("Theengs")
+         .setContentText("Scanning for sensors")
+         .setContentIntent(pi)
+         .setOngoing(true)
+         .setOnlyAlertOnce(true);
+        return b.build();
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -60,7 +136,14 @@ public class TheengsAndroidService extends QtService {
     public static void serviceStart(android.content.Context context) {
         android.content.Intent pQtAndroidService = new android.content.Intent(context, TheengsAndroidService.class);
         pQtAndroidService.addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK);
-        context.startService(pQtAndroidService);
+        // startForegroundService() is required since API 26 for the manifest's
+        // foregroundServiceType to take effect. onStartCommand() above promotes
+        // the service to foreground within the 5 s window Android allows.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            context.startForegroundService(pQtAndroidService);
+        } else {
+            context.startService(pQtAndroidService);
+        }
     }
 
     public static void serviceStop(android.content.Context context) {

--- a/src/SettingsManager.cpp
+++ b/src/SettingsManager.cpp
@@ -19,6 +19,10 @@
 #include "SettingsManager.h"
 #include "SystrayManager.h"
 
+#if defined(Q_OS_ANDROID)
+#include "AndroidService.h"
+#endif
+
 #include <QCoreApplication>
 #include <QSettings>
 #include <QLocale>
@@ -383,9 +387,7 @@ void SettingsManager::setSysTray(const bool value)
 {
     if (m_systrayEnabled != value)
     {
-#if !defined(Q_OS_ANDROID) && !defined(Q_OS_IOS)
         bool trayEnable_saved = m_systrayEnabled;
-#endif
         m_systrayEnabled = value;
         writeSettings();
 
@@ -403,6 +405,22 @@ void SettingsManager::setSysTray(const bool value)
                 st->installSystray();
                 Q_EMIT systrayChanged();
             }
+        }
+#endif
+
+#if defined(Q_OS_ANDROID)
+        // Start / stop the foreground BLE-scan service so the tray
+        // notification appears and disappears in lockstep with the
+        // "Enable background updates" toggle.
+        if (trayEnable_saved == true && m_systrayEnabled == false)
+        {
+            AndroidService::service_stop();
+            Q_EMIT systrayChanged();
+        }
+        else if (trayEnable_saved == false && m_systrayEnabled == true)
+        {
+            AndroidService::service_start();
+            Q_EMIT systrayChanged();
         }
 #endif
     }


### PR DESCRIPTION
## Description:
Without a foreground service, Android suspends the BLE scan callback ~28 s after the screen turns off (verified empirically on Samsung A52s/Android 14: vanilla App stops publishing scan results once mWakefulness flips Awake → Dozing). Bind the existing TheengsAndroidService as a typed FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE so the OS keeps the scan loop alive while the user is away from the App.

Five coordinated changes:
- Manifest: declare FOREGROUND_SERVICE (API 28+) and FOREGROUND_SERVICE_CONNECTED_DEVICE (API 34+) permissions plus android:foregroundServiceType="connectedDevice" on the service.
- TheengsAndroidService.onStartCommand: call startForeground with a low-importance "Scanning for sensors" notification before delegating to QtService. The notification channel is created lazily on first start; the notification is sticky and only alerts once.
- TheengsAndroidService.onDestroy: call stopForeground(STOP_FOREGROUND_REMOVE) so the tray notification clears when the user toggles off background updates, not just when the app process dies.
- serviceStart: use Context.startForegroundService() on API 26+ so the manifest's foregroundServiceType actually takes effect; the service must then call startForeground() within 5 s, which onStartCommand guarantees.
- SettingsManager::setSysTray: on Android, call AndroidService::service_start / service_stop in lockstep with the toggle, mirroring the existing desktop SystrayManager install/remove path. Previously the toggle only persisted the value; the service was only started once at app launch and never stopped, so the foreground notification stayed in the tray even after the user disabled background scanning.

Bench measurement on a Samsung phone with the patch installed:
- Screen-off, 5 min: 70 → 278 msgs (3.5×).
- Forced deep Doze, 60 min: 0 → 653 msgs. Two regimes — full delivery for the first ~8 min, then quantized to ~5-min Doze maintenance windows. Full Doze immunity still requires battery whitelisting, but maintenance-window delivery is enough to keep persisted sensors refreshing on a normal phone.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/app/blob/development/docs/participate/development.md#developer-certificate-of-origin).
