### PR TITLE
Fix H5055 multi-probe state wipe (theengs/decoder#92)

### DIFF
--- a/src/devices/device_theengs_probes.cpp
+++ b/src/devices/device_theengs_probes.cpp
@@ -213,12 +213,33 @@ void DeviceTheengsProbes::parseTheengsAdvertisement(const QString &json)
     }
     else // temperature probes
     {
-        m_temperature1 = -99.f;
-        m_temperature2 = -99.f;
-        m_temperature3 = -99.f;
-        m_temperature4 = -99.f;
-        m_temperature5 = -99.f;
-        m_temperature6 = -99.f;
+        // The H5055 is the only currently-supported probe that broadcasts
+        // one probe pair at a time (1&2, 3&4, or 5&6, gated by bits 2-3 of
+        // manufacturerdata[10] in H5055_json.h). Wiping all six slots on
+        // every advertisement would erase the previous pair's values before
+        // they can be merged with the new pair's, leaving only the most
+        // recent pair "live" — every probe outside that pair appears as
+        // disconnected ("-") even though it was just reported. See
+        // theengs/decoder#92 (AJolly's "App still thinks the thermometer is
+        // offline" report). Other probe devices (Inkbird IBT-2X/4XS/6XS,
+        // Xiaomi pressure monitors) include every probe in every broadcast
+        // and rely on the wipe-then-set pattern to surface disconnected
+        // probes — keep their behavior untouched.
+        //
+        // Match m_deviceModel exactly against the Theengs Decoder model_id
+        // ("H5055" — see thirdparty/TheengsDecoder/src/devices/H5055_json.h),
+        // mirroring how DeviceManager_theengs.cpp branches on deviceModelID
+        // (== "BM2", == "X1", == "W270160X", …). Substring would loose-match
+        // hypothetical variants ("H5055X") that may not share the quirk.
+        if (m_deviceModel != "H5055")
+        {
+            m_temperature1 = -99.f;
+            m_temperature2 = -99.f;
+            m_temperature3 = -99.f;
+            m_temperature4 = -99.f;
+            m_temperature5 = -99.f;
+            m_temperature6 = -99.f;
+        }
 
         QDateTime ts = QDateTime::currentDateTime();
 


### PR DESCRIPTION
## Description:
DeviceTheengsProbes::parseTheengsAdvertisement was unconditionally resetting all six m_temperature{1..6} slots to the -99.f sentinel at the start of every non-TPMS advertisement, then re-reading only the probes present in the current decoder JSON. For probe devices that include every probe in every broadcast (Inkbird IBT-2X/4XS/6XS, Xiaomi pressure monitor), this is fine — the absence of a tempcN field correctly signals "probe disconnected."

The Govee H5055 is the odd one out: it broadcasts one probe pair at a time (1&2, 3&4, or 5&6, gated by bits 2-3 of manufacturerdata[10] in H5055_json.h), so a frame containing only tempc3/tempc4 would erase the previously-decoded values for probes 1, 2, 5, 6 before componentText_3l could render them. Net effect: only the most recent pair shows real values; the other four probes display as "-" (-99.f triggers the componentText_3l Text else-branch), and the user sees probes disappearing on every refresh — AJolly's "App still thinks the thermometer is offline" symptom in theengs/decoder#92.

Skip the wipe for H5055 only; keep the existing behavior for every other probe device. m_temperature{1..6} default to -99.f in the header, so no-broadcast slots still render as "-".

Verified on the HIL bench with a three-pair sequence (H5055_09 → H5055_11 → H5055_10) under one shared MAC: before this change the row's descendant_texts ended up
    ('-', '-', '-', '-', '70°', '70°')
(only the 5&6 pair surviving). With the fix, all six probe values should be carried across.


## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/app/blob/development/docs/participate/development.md#developer-certificate-of-origin).
