### PR TITLE
Android: drop hardcoded android:debuggable="true" from manifest

### DIFF
--- a/assets/android/AndroidManifest.xml
+++ b/assets/android/AndroidManifest.xml
@@ -41,7 +41,6 @@
 
     <!-- Application -->
     <application android:name="org.qtproject.qt.android.bindings.QtApplication"
-                 android:debuggable="true"
                  android:hardwareAccelerated="true" android:allowNativeHeapPointerTagging="false"
                  android:theme="@style/AppTheme" android:roundIcon="@mipmap/ic_launcher_round" android:icon="@mipmap/ic_launcher"
                  android:label="Theengs BLE">


### PR DESCRIPTION
## Description:
lintVitalRelease (run by androiddeployqt --release on every AAB build, not just production) refuses to package a manifest that pins android:debuggable, blocking the internal-testing upload pipeline.

Gradle auto-flips debuggable on for `assembleDebug` and off for `assembleRelease`, so removing the attribute is the correct fix; nothing is lost for local debug builds.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/app/blob/development/docs/participate/development.md#developer-certificate-of-origin).
