### PR TITLE
CI: sign Android AAB with jarsigner before Play upload

### DIFF
--- a/.github/workflows/builds_mobile.yml
+++ b/.github/workflows/builds_mobile.yml
@@ -206,6 +206,24 @@ jobs:
              echo "===== gradle reports (if any errors) ====="
              find build/android-build/build/reports/ -type f -name '*.html' 2>&1 | head -10 || true
 
+      # Sign the AAB with jarsigner. Qt's QT_ANDROID_KEYSTORE_* CMake vars are
+      # read as target properties (not variables), so the -D flags we pass to
+      # qt-cmake don't propagate into androiddeployqt's --sign injection, and
+      # the AAB lands at outputs/bundle/release/ unsigned. Sign it ourselves
+      # using -storepass:env / -keypass:env so passwords never appear on argv.
+      - name: Sign AAB with jarsigner
+        if: env.DISTRIBUTE == 'true'
+        run: |
+             AAB=$(ls build/android-build/build/outputs/bundle/release/*.aab | head -n1)
+             echo "Signing: $AAB"
+             jarsigner -sigalg SHA256withRSA -digestalg SHA-256 \
+               -keystore "$ANDROID_KEYSTORE_PATH" \
+               -storepass:env ANDROID_KEYSTORE_PASSWORD \
+               -keypass:env ANDROID_KEY_PASSWORD \
+               "$AAB" "$ANDROID_KEY_ALIAS"
+             echo "Verifying signature..."
+             jarsigner -verify -strict "$AAB"
+
       # Upload AAB to Play Console (Internal testing track)
       - name: Upload AAB to Play Console
         if: env.DISTRIBUTE == 'true'


### PR DESCRIPTION
## Description:
Qt 6's QT_ANDROID_KEYSTORE_* values are read as target properties on the Android executable, not as CMake variables, so passing them with -D to qt-cmake doesn't reach androiddeployqt's --sign injection. The AAB lands unsigned and Play Console rejects it with "All uploaded bundles must be signed".

Sign the produced AAB explicitly with jarsigner after the build, using -storepass:env / -keypass:env so the keystore + key passwords are read from environment variables instead of appearing on argv (where they'd show up in process listings and could leak through `ps`).

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/app/blob/development/docs/participate/development.md#developer-certificate-of-origin).
