### PR TITLE
CI: drop -strict from jarsigner verify

### DIFF
--- a/.github/workflows/builds_mobile.yml
+++ b/.github/workflows/builds_mobile.yml
@@ -221,8 +221,13 @@ jobs:
                -storepass:env ANDROID_KEYSTORE_PASSWORD \
                -keypass:env ANDROID_KEY_PASSWORD \
                "$AAB" "$ANDROID_KEY_ALIAS"
+             # Verify the signature. Do NOT use -strict: Android upload keys
+             # are self-signed by design, and -strict treats self-signed certs
+             # plus the missing TSA timestamp as errors. "jar verified" without
+             # a non-zero exit is what we need; the self-signed / no-timestamp
+             # warnings are expected and benign for Play Console uploads.
              echo "Verifying signature..."
-             jarsigner -verify -strict "$AAB"
+             jarsigner -verify "$AAB"
 
       # Upload AAB to Play Console (Internal testing track)
       - name: Upload AAB to Play Console


### PR DESCRIPTION
## Description:
Android upload keys are self-signed by design. jarsigner -verify -strict treats the self-signed cert chain (and the absent TSA timestamp) as errors, failing the verification step even though the AAB is correctly signed and Play Console will accept it. Drop -strict so verification exits 0 on the warnings that are inherent to Android upload signing.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/app/blob/development/docs/participate/development.md#developer-certificate-of-origin).
