### PR TITLE
CI: tell xcodebuild which provisioning profile to use on iOS

### DIFF
--- a/.github/workflows/builds_mobile.yml
+++ b/.github/workflows/builds_mobile.yml
@@ -333,7 +333,9 @@ jobs:
                  -DCMAKE_PREFIX_PATH:PATH="${QT_TARGET_PATH}" \
                  -DQT_HOST_PATH:PATH="${QT_HOST_PATH}" \
                  -DCMAKE_XCODE_ATTRIBUTE_DEVELOPMENT_TEAM="${APPLE_TEAM_ID}" \
-                 -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGN_STYLE=Manual
+                 -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGN_STYLE=Manual \
+                 -DCMAKE_XCODE_ATTRIBUTE_PROVISIONING_PROFILE_SPECIFIER="Theengs App Store" \
+                 -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY="Apple Distribution"
              else
                "${QT_TARGET_PATH}/bin/qt-cmake" -B build/ -G Xcode \
                  -DCMAKE_SYSTEM_NAME=iOS \


### PR DESCRIPTION
## Description:
With CODE_SIGN_STYLE=Manual, xcodebuild rejects the archive step with "requires a provisioning profile. Select a provisioning profile in the Signing & Capabilities editor" unless we explicitly point at one. apple-actions/download-provisioning-profiles installs the profile into ~/Library/MobileDevice/Provisioning Profiles/ but xcodebuild won't pick it up without PROVISIONING_PROFILE_SPECIFIER set on the target.

Pin the specifier to the expected profile name "Theengs App Store" and the signing identity to "Apple Distribution" so the archive resolves the profile + cert pair deterministicall

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/app/blob/development/docs/participate/development.md#developer-certificate-of-origin).
