### PR TITLE
CI: build iOS against Xcode latest-stable (iOS 26 SDK requirement)

### DIFF
--- a/.github/workflows/builds_mobile.yml
+++ b/.github/workflows/builds_mobile.yml
@@ -244,7 +244,10 @@ jobs:
   ## iOS build #################################################################
   build-ios:
     name: "iOS CI build"
-    runs-on: macos-15
+    # macos-latest tracks GitHub's current macOS image and ships the most recent
+    # Xcode. App Store Connect now requires builds against the iOS 26 SDK
+    # (Xcode 26+); macos-15 with Xcode 16.x is rejected at upload validation.
+    runs-on: macos-latest
     env:
       DISTRIBUTE: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/development' || startsWith(github.ref, 'refs/tags/v')) && github.repository == 'theengs/app' }}
       REPO_NAME: ${{ github.event.repository.name }}
@@ -254,6 +257,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      # Pin Xcode to the latest stable version available on the runner so
+      # builds are reproducible and we get the iOS 26+ SDK that App Store
+      # Connect now requires for uploads.
+      - name: Select latest Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
 
       # Install Qt (desktop & iOS)
       - name: Install Qt (desktop & iOS)


### PR DESCRIPTION
## Description:
App Store Connect now rejects uploads built with anything older than the iOS 26 SDK / Xcode 26. The macos-15 runner with Xcode 16.4 hits "SDK version issue" at the exportArchive validation step.

Switch the iOS job to macos-latest (the rolling label that tracks GitHub's current macOS image with the freshest Xcode) and explicitly select latest-stable Xcode via maxim-lobanov/setup-xcode so the build gets the iOS 26+ SDK Apple requires.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/app/blob/development/docs/participate/development.md#developer-certificate-of-origin).
