### PR TITLE
iOS: add NSLocationAlwaysAndWhenInUseUsageDescription to Info.plist

### DIFF
--- a/assets/ios/Info.plist
+++ b/assets/ios/Info.plist
@@ -63,5 +63,7 @@
 	<string>Allow notifications alerts while on the sensor screen.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Allow the application to know what wifi network its currently connected to.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>Allow the application to know what wifi network its currently connected to.</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Description:
Fixes App Store Connect ITMS-90683 rejection — an external SDK references the "Always" location API, so Apple requires the purpose string even though the app itself only uses when-in-use location for WiFi network detection.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/app/blob/development/docs/participate/development.md#developer-certificate-of-origin).
