### PR TITLE
Fix Govee thermometers labeled "iBeacon" after Theengs adv rework

### DIFF
--- a/src/DeviceManager_advertisement.cpp
+++ b/src/DeviceManager_advertisement.cpp
@@ -197,10 +197,15 @@ void DeviceManager::bleDevice_updated(const QBluetoothDeviceInfo &info, QBluetoo
                 ArduinoJson::JsonObject obj = doc.as<ArduinoJson::JsonObject>();
                 if (decoder.decodeBLEJson(obj) >= 0)
                 {
+                    // iBeacon packets overlap with the real device adv (e.g. Govee thermometers
+                    // broadcast both); skip without updating model_id so a later iteration on the
+                    // device-specific mfg/service data can label it correctly.
+                    if (doc["model_id"] == "IBEACON") continue;
+
                     dd->setTheengsModelId(QString::fromStdString(doc["model"]), QString::fromStdString(doc["model_id"]));
 
-                    // Do not process devices with random macs or IBEACONS packets
-                    if (doc["type"] == "RMAC" || doc["prmac"] || doc["model_id"] == "IBEACON") break;
+                    // Do not process devices with random macs
+                    if (doc["type"] == "RMAC" || doc["prmac"]) break;
 
                     obj.remove("manufacturerdata");
                     obj.remove("servicedata");

--- a/src/DeviceManager_theengs.cpp
+++ b/src/DeviceManager_theengs.cpp
@@ -236,7 +236,7 @@ Device * DeviceManager::createTheengsDevice_fromAdv(const QBluetoothDeviceInfo &
 
         if (!deviceModelID.isEmpty() && // Do not process unkown devices
             !deviceProps.isEmpty() && // Do not process devices with empty properties
-            !(deviceTypes == "RMAC" || doc["prmac"])) // Do not process devices with random macs
+            !(deviceTypes == "RMAC" || doc["prmac"] || deviceModelID == "IBEACON")) // Random-MAC or iBeacon-only packets (e.g. Govee thermometers also broadcast iBeacon) — let the next iteration try the device-specific adv
         {
             int deviceType = DeviceTheengs::getTheengsTypeFromTag(deviceTags, deviceTypes);
 


### PR DESCRIPTION
## Description:
Govee H5xxx (and similar) thermometers broadcast two manufacturer data frames per advertisement: their own (mfg id 0x88EC) and an Apple iBeacon (0x004C). Since 64988a1 reworked createTheengsDevice_fromAdv() into a per-mfg-id loop, the first decoder match wins. When the iBeacon frame is iterated first, the device is created/relabeled as IBEACON and the Govee frame is never tried.

Two paths needed the iBeacon skip:

- DeviceManager_theengs.cpp: extend the create-path filter so an IBEACON match doesn't short-circuit device creation; the loop now continues to the next mfg/service data slot and picks up the real Govee model.

- DeviceManager_advertisement.cpp: the known-device update path was calling setTheengsModelId() *before* the IBEACON filter, so even an already-correct Govee row got clobbered back to IBEACON on every advertisement where the iBeacon frame was iterated first. Move the IBEACON check ahead of setTheengsModelId() and switch break->continue so the device-specific iteration can update model_id and publish MQTT.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/app/blob/development/docs/participate/development.md#developer-certificate-of-origin).
