### PR TITLE
Feat/android fgs live notification

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,7 @@ if(IOS OR ANDROID)
     set(QAPPLICATION_CLASS QGuiApplication)
     set(SOURCES_MOBILE
         src/AndroidService.cpp src/AndroidService.h
+        src/ForegroundNotifier.cpp src/ForegroundNotifier.h
     )
 endif()
 

--- a/assets/android/res/values/strings.xml
+++ b/assets/android/res/values/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Foreground-service notification (BLE scanning bridge) -->
+    <string name="fgs_channel_name">Theengs background service</string>
+    <string name="fgs_channel_description">Keeps the BLE scan running while the app is in the background.</string>
+    <string name="fgs_title_default">Theengs \u00b7 Scanning Bluetooth sensors</string>
+    <string name="fgs_body_default">Listening for BLE sensor advertisements\u2026</string>
+    <string name="fgs_action_stop">Stop</string>
+</resources>

--- a/assets/android/src/com/theengs/app/TheengsAndroidService.java
+++ b/assets/android/src/com/theengs/app/TheengsAndroidService.java
@@ -18,7 +18,6 @@
 
 package com.theengs.app;
 
-import java.lang.String;
 import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
@@ -26,9 +25,13 @@ import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.content.pm.ServiceInfo;
 import android.os.Build;
 import android.util.Log;
+
+import androidx.core.app.NotificationCompat;
+import androidx.core.app.ServiceCompat;
 
 import org.qtproject.qt.android.bindings.QtService;
 
@@ -36,13 +39,47 @@ public class TheengsAndroidService extends QtService {
 
     private static final String TAG = "TheengsAndroidService";
     // Foreground-service notification id + channel. Fixed per-process so
-    // startForeground/stopForeground refer to the same notification.
+    // startForeground/stopForeground/notify all target the same notification.
     private static final int NOTIFICATION_ID = 1001;
     private static final String CHANNEL_ID = "TheengsForegroundService";
+    // Package-scoped action so the Stop button only ever wakes our own
+    // receiver. Registered dynamically in onCreate() (RECEIVER_NOT_EXPORTED
+    // on API 33+) so we don't need a manifest <receiver> entry.
+    private static final String ACTION_STOP_FGS = "com.theengs.app.action.STOP_FGS";
+
+    // Live notification content fed from C++ via updateNotification().
+    // volatile because the static setter is called from the Qt main thread of
+    // the service process while buildNotification() runs on this service's
+    // main thread.
+    private static volatile String sTitle;
+    private static volatile String sBody;
+    private static volatile String sBigText;
+    private static volatile TheengsAndroidService sInstance;
+
+    private final BroadcastReceiver mStopReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            Log.i(TAG, "Stop action received — stopping service");
+            stopSelf();
+        }
+    };
 
     @Override
     public void onCreate() {
         super.onCreate();
+        sInstance = this;
+        IntentFilter filter = new IntentFilter(ACTION_STOP_FGS);
+        try {
+            // RECEIVER_NOT_EXPORTED is required on API 34+ for unprotected
+            // dynamically-registered receivers; harmless flag on 33.
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                registerReceiver(mStopReceiver, filter, Context.RECEIVER_NOT_EXPORTED);
+            } else {
+                registerReceiver(mStopReceiver, filter);
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "registerReceiver failed", e);
+        }
     }
 
     public void onResume() {
@@ -55,14 +92,17 @@ public class TheengsAndroidService extends QtService {
 
     @Override
     public void onDestroy() {
-        // Clear the foreground notification on stopService() so it doesn't
-        // linger in the tray after the user toggles off background scanning.
+        sInstance = null;
         try {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                stopForeground(STOP_FOREGROUND_REMOVE);
-            } else {
-                stopForeground(true);
-            }
+            unregisterReceiver(mStopReceiver);
+        } catch (Exception e) {
+            // Swallow: receiver may not have registered if onCreate threw.
+        }
+        // Clear the foreground notification on stopService() / stopSelf() so
+        // it doesn't linger in the tray after the user toggles off background
+        // scanning or presses the Stop action.
+        try {
+            ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE);
         } catch (Exception e) {
             Log.e(TAG, "stopForeground failed", e);
         }
@@ -77,41 +117,45 @@ public class TheengsAndroidService extends QtService {
         // FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE because the service
         // exists to keep BLE scan callbacks alive while the screen is off.
         startInForeground();
-        int ret = super.onStartCommand(intent, flags, startId);
+        super.onStartCommand(intent, flags, startId);
         return START_STICKY;
     }
 
     private void startInForeground() {
         try {
-            Notification notification = buildNotification();
+            ensureChannel();
+            Notification n = buildNotification();
+            // androidx.core 1.6.1 ships ServiceCompat.startForeground only in
+            // its 3-arg form; the typed 4-arg overload landed in 1.12.0. We're
+            // pinned to 1.6.1, so branch manually on API 34 instead of bumping
+            // the dependency (the policy comment above still applies).
             if (Build.VERSION.SDK_INT >= 34) {
-                startForeground(
-                    NOTIFICATION_ID,
-                    notification,
-                    ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE
-                );
+                startForeground(NOTIFICATION_ID, n,
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE);
             } else {
-                startForeground(NOTIFICATION_ID, notification);
+                startForeground(NOTIFICATION_ID, n);
             }
         } catch (Exception e) {
             Log.e(TAG, "startForeground failed", e);
         }
     }
 
-    private Notification buildNotification() {
+    private void ensureChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return;
         NotificationManager nm =
             (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            NotificationChannel ch = new NotificationChannel(
-                CHANNEL_ID,
-                "Theengs background service",
-                NotificationManager.IMPORTANCE_LOW
-            );
-            ch.setDescription("Keeps the BLE scan running while the app is in the background");
-            nm.createNotificationChannel(ch);
-        }
-        Intent launch =
-            getPackageManager().getLaunchIntentForPackage(getPackageName());
+        if (nm == null) return;
+        NotificationChannel ch = new NotificationChannel(
+            CHANNEL_ID,
+            getString(R.string.fgs_channel_name),
+            NotificationManager.IMPORTANCE_LOW
+        );
+        ch.setDescription(getString(R.string.fgs_channel_description));
+        ch.setShowBadge(false);
+        nm.createNotificationChannel(ch);
+    }
+
+    private PendingIntent makeContentIntent() {
         // FLAG_ACTIVITY_CLEAR_TOP + FLAG_ACTIVITY_SINGLE_TOP: bring the existing
         // QtActivity instance to the foreground (delivering onNewIntent) instead
         // of letting Android spin up a fresh ActivityRecord every time the user
@@ -120,26 +164,65 @@ public class TheengsAndroidService extends QtService {
         // timeout" failure mode where rapid relaunches on a slow device
         // (observed on LG V30 / Android 9) deadlock the Qt main thread and
         // SurfaceFlinger never receives a BufferLayer for the new task.
-        launch.addFlags(
-            Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP
-        );
-        PendingIntent pi = PendingIntent.getActivity(
+        Intent launch = getPackageManager().getLaunchIntentForPackage(getPackageName());
+        if (launch == null) {
+            launch = new Intent(Intent.ACTION_MAIN).setPackage(getPackageName());
+        }
+        launch.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        return PendingIntent.getActivity(
             this, 0, launch,
             PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE
         );
-        Notification.Builder b;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            b = new Notification.Builder(this, CHANNEL_ID);
-        } else {
-            b = new Notification.Builder(this);
-        }
-        b.setSmallIcon(R.drawable.ic_stat_logo)
-         .setContentTitle("Theengs")
-         .setContentText("Scanning for sensors")
-         .setContentIntent(pi)
-         .setOngoing(true)
-         .setOnlyAlertOnce(true);
+    }
+
+    private PendingIntent makeStopIntent() {
+        Intent stop = new Intent(ACTION_STOP_FGS).setPackage(getPackageName());
+        return PendingIntent.getBroadcast(
+            this, 0, stop,
+            PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE
+        );
+    }
+
+    private Notification buildNotification() {
+        String title = sTitle != null ? sTitle : getString(R.string.fgs_title_default);
+        String body  = sBody  != null ? sBody  : getString(R.string.fgs_body_default);
+        String big   = sBigText != null && !sBigText.isEmpty() ? sBigText : body;
+
+        NotificationCompat.Builder b = new NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_stat_logo)
+            .setContentTitle(title)
+            .setContentText(body)
+            .setStyle(new NotificationCompat.BigTextStyle().bigText(big))
+            .setContentIntent(makeContentIntent())
+            .setOngoing(true)
+            .setOnlyAlertOnce(true)
+            .setShowWhen(false)
+            .setCategory(NotificationCompat.CATEGORY_SERVICE)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
+            .addAction(0, getString(R.string.fgs_action_stop), makeStopIntent());
         return b.build();
+    }
+
+    /**
+     * JNI entry point called from C++ ForegroundNotifier on the service
+     * process's Qt main thread. Re-renders the FGS notification with the
+     * supplied content. No-op if the service has been torn down between
+     * the C++ side queuing an update and us reaching this method.
+     */
+    public static void updateNotification(String title, String body, String bigText) {
+        sTitle = title;
+        sBody = body;
+        sBigText = bigText;
+        TheengsAndroidService self = sInstance;
+        if (self == null) return;
+        try {
+            NotificationManager nm =
+                (NotificationManager) self.getSystemService(Context.NOTIFICATION_SERVICE);
+            if (nm != null) nm.notify(NOTIFICATION_ID, self.buildNotification());
+        } catch (Exception e) {
+            Log.e(TAG, "updateNotification failed", e);
+        }
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/qml/Settings.qml
+++ b/qml/Settings.qml
@@ -436,10 +436,10 @@ Item {
 
                     visible: (Qt.platform.os === "android")
 
-                    text: qsTr("experimental")
-                    colorHighlight: Theme.colorRed
-                    colorBorder: Theme.colorRed
-                    colorText: Theme.colorRed
+                    text: qsTr("Beta")
+                    colorHighlight: Theme.colorPrimary
+                    colorBorder: Theme.colorPrimary
+                    colorText: Theme.colorPrimary
 
                     onClicked: popupBackgroundUpdates.open()
                 }
@@ -520,8 +520,8 @@ Item {
 
                 visible: (Qt.platform.os === "android") // && (settingsManager.systray && element_worker.visible)
 
-                text: qsTr("Wake up at a predefined interval to refresh sensor data. Only if Bluetooth (or Bluetooth control) is enabled.")
-                textFormat: Text.PlainText
+                text: qsTr("Theengs keeps scanning for sensors when the app is closed, and refreshes their values on a regular interval. An ongoing notification appears while scanning — tap <b>Stop</b> there to turn it off at any time. Requires Bluetooth to be on.")
+                textFormat: Text.StyledText
                 wrapMode: Text.WordWrap
                 color: Theme.colorSubText
                 font.pixelSize: Theme.fontSizeContentSmall

--- a/qml/popups/PopupBackgroundUpdates.qml
+++ b/qml/popups/PopupBackgroundUpdates.qml
@@ -87,7 +87,7 @@ Popup {
                     Text {
                         width: parent.width
 
-                        text: qsTr("To use the background update feature, the <b>background location permission</b> is required, otherwise Theengs can't scan for Bluetooth Low Energy sensors and can't update data when the app is closed.")
+                        text: qsTr("To scan for Bluetooth Low Energy sensors in the background, Android requires the <b>background location permission</b> — this is an OS-level requirement that applies to all BLE apps. Theengs only reads sensor advertisements; it does <b>not</b> track your location.<br><br>While scanning, an ongoing notification appears in your status bar so you always know Theengs is active. Tap <b>Stop</b> there to turn it off at any time.")
                         textFormat: Text.StyledText
                         font.pixelSize: Theme.fontSizeContent
                         color: Theme.colorSubText
@@ -170,8 +170,7 @@ Popup {
 
                     Text {
                         width: parent.width
-                        text: qsTr("Your phone will do its best to prevent this application from running in the background.") + "<br>" +
-                              qsTr("Some settings need to be switched <b>manually</b> from the Android <b>application info panel</b>:")
+                        text: qsTr("Some Android phones aggressively pause background apps to save battery, which can interrupt sensor scanning. For reliable updates, you may need to adjust a few settings from the Android <b>app info</b> screen:")
                         textFormat: Text.StyledText
                         font.pixelSize: Theme.fontSizeContent
                         color: Theme.colorSubText
@@ -180,8 +179,8 @@ Popup {
 
                     Text {
                         width: parent.width
-                        text: qsTr("- autolaunch will need to be <b>enabled</b>") + "<br>" +
-                              qsTr("- battery saving feature(s) will need to be <b>disabled</b>")
+                        text: qsTr("- exclude Theengs from <b>battery optimisation</b>") + "<br>" +
+                              qsTr("- on some devices (Xiaomi, OPPO, Huawei…), <b>autolaunch</b> must also be enabled")
                         textFormat: Text.StyledText
                         font.pixelSize: Theme.fontSizeContent
                         color: Theme.colorSubText

--- a/src/AndroidService.cpp
+++ b/src/AndroidService.cpp
@@ -25,6 +25,7 @@
 #include "DeviceManager.h"
 #include "MqttManager.h"
 #include "NotificationManager.h"
+#include "ForegroundNotifier.h"
 
 #include <QtCore/private/qandroidextras_p.h>
 #include <QCoreApplication>
@@ -42,6 +43,10 @@ AndroidService::AndroidService(QObject *parent) : QObject(parent)
 
     //m_notificationManager = NotificationManager::getInstance(); // DEBUG
     //m_notificationManager->setNotification("AndroidService starting", QDateTime::currentDateTime().toString());
+
+    // Pushes live BLE-reading content into the foreground-service
+    // notification owned by the :qt_service process.
+    m_foregroundNotifier = new ForegroundNotifier(this);
 
     // Configure update timer
     connect(&m_workTimer, &QTimer::timeout, this, &AndroidService::gotowork);
@@ -75,6 +80,11 @@ void AndroidService::gotowork()
         // Reload the device manager, a new scan might have occured
         if (m_deviceManager) delete m_deviceManager;
         m_deviceManager = new DeviceManager(true);
+
+        // Hand the fresh DeviceManager to the foreground-service notifier so
+        // it re-attaches to the per-Device dataUpdated() signals (the old
+        // manager's Devices were destroyed with it).
+        if (m_foregroundNotifier) m_foregroundNotifier->attachDeviceManager(m_deviceManager);
 
         // Device manager is operational?
         if (m_deviceManager &&

--- a/src/AndroidService.h
+++ b/src/AndroidService.h
@@ -27,6 +27,7 @@
 class DeviceManager;
 class SettingsManager;
 class NotificationManager;
+class ForegroundNotifier;
 
 #if defined(Q_OS_ANDROID)
 /* ************************************************************************** */
@@ -44,6 +45,7 @@ class AndroidService: public QObject
     DeviceManager *m_deviceManager = nullptr;
     SettingsManager *m_settingsManager = nullptr;
     NotificationManager *m_notificationManager = nullptr;
+    ForegroundNotifier *m_foregroundNotifier = nullptr;
 
 private slots:
     void gotowork();

--- a/src/DeviceManager.h
+++ b/src/DeviceManager.h
@@ -298,6 +298,7 @@ public:
     int getDeviceCount() const { return m_devices_model->getDeviceCount(); }
     DeviceFilter *getDevicesFiltered() const { return m_devices_filter; }
     DeviceFilter *getDevicesNearby() const { return m_devices_nearby_filter; }
+    const QList<Device *> &getDeviceList() const { return m_devices_model->m_devices; }
 
     // Gateway management
     Q_INVOKABLE void removeGateway(const QString &address);

--- a/src/ForegroundNotifier.cpp
+++ b/src/ForegroundNotifier.cpp
@@ -1,0 +1,255 @@
+/*
+    Theengs - Decode things and devices
+    Copyright: (c) Florian ROBERT
+
+    This file is part of Theengs.
+
+    Theengs is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    Theengs is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "ForegroundNotifier.h"
+
+#if defined(Q_OS_ANDROID)
+
+#include "DeviceManager.h"
+#include "DeviceFilter.h"
+#include "device.h"
+
+#include <QJniObject>
+#include <QStringList>
+#include <QVariant>
+#include <QtMath>
+#include <QDebug>
+
+/* ************************************************************************** */
+
+namespace {
+
+// Ordered list of Q_PROPERTY names the C++ Device subclasses expose; we
+// surface the first 1-2 that resolve to a sensible numeric value. The unit
+// strings here are the canonical SI / common ones used elsewhere in the app;
+// the notification is informational so we don't localise the unit per-locale
+// in v1 (this stays consistent with how Settings already labels values).
+struct KnownProp { const char *prop; const char *unit; int precision; };
+constexpr KnownProp kKnownProps[] = {
+    { "temperature", "\u00b0C", 1 },   // °C
+    { "humidity",    "%",       0 },
+    { "co2",         "ppm",     0 },
+    { "voc",         "ppb",     0 },
+    { "pm25",        "\u00b5g/m\u00b3", 0 }, // µg/m³
+    { "pressure",    "hPa",     0 },
+    { "luminosity",  "lx",      0 },
+    { "weight",      "kg",      2 },
+};
+
+bool readDouble(const QVariant &v, double &out)
+{
+    if (!v.isValid()) return false;
+    bool ok = false;
+    double d = v.toDouble(&ok);
+    if (!ok) return false;
+    if (qIsNaN(d)) return false;
+    out = d;
+    return true;
+}
+
+} // namespace
+
+/* ************************************************************************** */
+
+ForegroundNotifier::ForegroundNotifier(QObject *parent) : QObject(parent)
+{
+    m_debounce.setSingleShot(true);
+    m_debounce.setInterval(kDebounceMs);
+    connect(&m_debounce, &QTimer::timeout, this, &ForegroundNotifier::flush);
+
+    m_refresh.setInterval(kRefreshMs);
+    connect(&m_refresh, &QTimer::timeout, this, &ForegroundNotifier::flush);
+    m_refresh.start();
+}
+
+ForegroundNotifier::~ForegroundNotifier() = default;
+
+/* ************************************************************************** */
+
+void ForegroundNotifier::attachDeviceManager(DeviceManager *dm)
+{
+    if (m_dm == dm && dm != nullptr) {
+        rewireDeviceList();
+        return;
+    }
+
+    if (m_dm) {
+        disconnect(m_dm, nullptr, this, nullptr);
+    }
+    // QObject::sender() returns nullptr for already-destroyed senders, so
+    // m_wired entries become safe stale pointers — clear and rewire.
+    m_wired.clear();
+    m_dm = dm;
+
+    if (m_dm) {
+        connect(m_dm, &DeviceManager::devicesListUpdated,
+                this, &ForegroundNotifier::onDeviceListChanged);
+        rewireDeviceList();
+    }
+}
+
+void ForegroundNotifier::rewireDeviceList()
+{
+    if (!m_dm) return;
+    for (Device *d : m_dm->getDeviceList()) {
+        if (!d) continue;
+        if (m_wired.contains(d)) continue;
+        connect(d, &Device::dataUpdated,
+                this, &ForegroundNotifier::onDeviceUpdated,
+                Qt::UniqueConnection);
+        m_wired.insert(d);
+    }
+}
+
+void ForegroundNotifier::onDeviceListChanged()
+{
+    rewireDeviceList();
+}
+
+/* ************************************************************************** */
+
+void ForegroundNotifier::onDeviceUpdated()
+{
+    Device *d = qobject_cast<Device *>(sender());
+    if (!d) return;
+
+    Reading r;
+    r.device = d;
+    // Label fallback: user location > BLE name > Theengs model > last 5 of
+    // MAC. Devices early in their discovery often have no name yet, so we
+    // need a stable identifier for the bigText line rather than "(unnamed)".
+    const QString loc   = d->getLocationName();
+    const QString name  = d->getName();
+    const QString model = d->getModel();
+    const QString addr  = d->getAddress();
+    if (!loc.isEmpty())        r.label = loc;
+    else if (!name.isEmpty())  r.label = name;
+    else if (!model.isEmpty()) r.label = model;
+    else if (!addr.isEmpty())  r.label = QStringLiteral("…") + addr.right(5);
+    else                       r.label = QStringLiteral("(BLE)");
+    r.valueSummary = formatValueSummary(d);
+    r.when = QDateTime::currentDateTime();
+
+    // De-dup by device pointer: most recent reading per device wins.
+    for (int i = 0; i < m_recent.size(); ++i) {
+        if (m_recent[i].device == d) {
+            m_recent.removeAt(i);
+            break;
+        }
+    }
+    m_recent.prepend(r);
+    while (m_recent.size() > kMaxRecent) m_recent.removeLast();
+
+    if (!m_debounce.isActive()) m_debounce.start();
+}
+
+/* ************************************************************************** */
+
+QString ForegroundNotifier::formatValueSummary(Device *d) const
+{
+    if (!d) return {};
+    QStringList parts;
+    for (const auto &kp : kKnownProps) {
+        QVariant v = d->property(kp.prop);
+        double x = 0.0;
+        if (!readDouble(v, x)) continue;
+        // Theengs Device subclasses use -99 / -99.0 as a "no reading yet"
+        // sentinel across many sensors (temperature, humidity, co2, voc,
+        // pm25...). Drop those so the notification doesn't surface garbage.
+        if (x <= -98.9) continue;
+        // Skip zeros for properties that almost always read as 0 when
+        // uninitialised (humidity / co2 / etc.). Temperature stays even at
+        // 0.0 since it's a legitimate value.
+        if (qFuzzyIsNull(x) && QByteArray(kp.prop) != QByteArray("temperature"))
+            continue;
+        parts.append(QStringLiteral("%1\u202F%2")
+                     .arg(QString::number(x, 'f', kp.precision))
+                     .arg(QString::fromUtf8(kp.unit)));
+        if (parts.size() >= 2) break; // cap at two values per device
+    }
+    return parts.join(QStringLiteral(" \u00b7 "));
+}
+
+QString ForegroundNotifier::relativeAge(const QDateTime &when, const QDateTime &now) const
+{
+    qint64 secs = when.secsTo(now);
+    if (secs < 0) secs = 0;
+    if (secs < 60) return tr("%1 s ago").arg(secs);
+    if (secs < 3600) return tr("%1 min ago").arg(secs / 60);
+    return tr("%1 h ago").arg(secs / 3600);
+}
+
+/* ************************************************************************** */
+
+void ForegroundNotifier::flush()
+{
+    if (m_recent.isEmpty()) return; // nothing to show yet — keep defaults
+    pushUpdate();
+}
+
+void ForegroundNotifier::pushUpdate()
+{
+    const QDateTime now = QDateTime::currentDateTime();
+
+    // "active" = distinct labels seen within the last kActiveWindowSecs.
+    int active = 0;
+    for (const Reading &r : std::as_const(m_recent)) {
+        if (r.when.secsTo(now) <= kActiveWindowSecs) ++active;
+    }
+    if (active < 1) active = m_recent.size();
+
+    const QDateTime &mostRecent = m_recent.first().when;
+    const QString title = tr("Theengs \u00b7 Scanning Bluetooth sensors");
+    // Qt's tr("%n …", n) plural form only switches catalogues when one is
+    // loaded; with no Android-side translation catalog, %n leaves "(s)"
+    // visible. Build the singular/plural form ourselves.
+    const QString sensorWord = (active == 1) ? tr("sensor") : tr("sensors");
+    const QString body = tr("%1 %2 active \u00b7 last reading %3")
+                         .arg(active)
+                         .arg(sensorWord)
+                         .arg(relativeAge(mostRecent, now));
+
+    QStringList lines;
+    lines.reserve(m_recent.size());
+    for (const Reading &r : std::as_const(m_recent)) {
+        QString line = r.label;
+        if (!r.valueSummary.isEmpty()) {
+            line += QStringLiteral(" \u00b7 ") + r.valueSummary;
+        }
+        line += QStringLiteral(" \u00b7 ") + relativeAge(r.when, now);
+        lines.append(line);
+    }
+    const QString bigText = lines.join(QChar('\n'));
+
+    // JNI: TheengsAndroidService.updateNotification(String, String, String)
+    QJniObject jTitle = QJniObject::fromString(title);
+    QJniObject jBody  = QJniObject::fromString(body);
+    QJniObject jBig   = QJniObject::fromString(bigText);
+    QJniObject::callStaticMethod<void>(
+        "com/theengs/app/TheengsAndroidService",
+        "updateNotification",
+        "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V",
+        jTitle.object<jstring>(),
+        jBody.object<jstring>(),
+        jBig.object<jstring>()
+    );
+}
+
+/* ************************************************************************** */
+
+#endif // Q_OS_ANDROID

--- a/src/ForegroundNotifier.h
+++ b/src/ForegroundNotifier.h
@@ -1,0 +1,95 @@
+/*
+    Theengs - Decode things and devices
+    Copyright: (c) Florian ROBERT
+
+    This file is part of Theengs.
+
+    Theengs is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    Theengs is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef FOREGROUND_NOTIFIER_H
+#define FOREGROUND_NOTIFIER_H
+/* ************************************************************************** */
+
+#include <QtGlobal>
+
+#if defined(Q_OS_ANDROID)
+
+#include <QObject>
+#include <QPointer>
+#include <QString>
+#include <QDateTime>
+#include <QList>
+#include <QSet>
+#include <QTimer>
+
+class Device;
+class DeviceManager;
+
+/*!
+ * \brief Feeds live BLE-reading content into the Theengs Android foreground
+ *        service notification. Lives in the :qt_service process and pushes
+ *        updates via JNI to TheengsAndroidService.updateNotification().
+ *
+ * Triggered by per-Device dataUpdated() signals, debounced to at most one
+ * notification rebuild every ~3 s, plus a 10 s tick that refreshes the
+ * "Xs ago" math even when no fresh readings arrive.
+ */
+class ForegroundNotifier: public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit ForegroundNotifier(QObject *parent = nullptr);
+    ~ForegroundNotifier() override;
+
+    /*! Re-points the notifier at a (possibly new) DeviceManager. Safe to
+     *  call repeatedly — re-attaches to the current device list and the
+     *  manager's devicesListUpdated signal so newly-discovered Devices
+     *  are picked up too. */
+    void attachDeviceManager(DeviceManager *dm);
+
+private slots:
+    void onDeviceUpdated();
+    void onDeviceListChanged();
+    void flush();
+
+private:
+    struct Reading {
+        QPointer<Device> device;
+        QString label;        // location if set, else device name
+        QString valueSummary; // e.g. "21.4 °C · 56 %" — may be empty
+        QDateTime when;
+    };
+
+    void rewireDeviceList();
+    QString formatValueSummary(Device *d) const;
+    QString relativeAge(const QDateTime &when, const QDateTime &now) const;
+    void pushUpdate();
+
+    QPointer<DeviceManager> m_dm;
+    QSet<Device *> m_wired;     // devices we've connected dataUpdated() on
+    QList<Reading> m_recent;    // most-recent first; capped at kMaxRecent
+
+    QTimer m_debounce;          // single-shot trailing-edge, kDebounceMs
+    QTimer m_refresh;           // periodic, kRefreshMs
+
+    static constexpr int kMaxRecent = 6;
+    static constexpr int kDebounceMs = 3000;
+    static constexpr int kRefreshMs = 10000;
+    static constexpr int kActiveWindowSecs = 5 * 60;
+};
+
+#endif // Q_OS_ANDROID
+
+/* ************************************************************************** */
+#endif // FOREGROUND_NOTIFIER_H


### PR DESCRIPTION
## Description:
Replace the static "Theengs is running" FGS notification with one that demonstrates ongoing connected-device data transfer.

  Title:  Theengs · Scanning Bluetooth sensors
  Body:   3 sensors active · last reading 0 s ago    (live, debounced)
  BigText (expanded):
    P T EN 811415 · 24.6 °C · 0 s ago
    Living room · 21.4 °C · 56 % · 2 s ago
    …                                                  (up to 6 entries)
  Action: Stop  (broadcast → stopSelf → clean teardown)

Wiring:

* TheengsAndroidService.java — NotificationCompat.Builder + BigTextStyle, dynamic Stop BroadcastReceiver (RECEIVER_NOT_EXPORTED on API 33+), strings via R.string.*, channel description, static updateNotification() exposed for JNI from the C++ side. Kept the manual API-34 startForeground branch because androidx.core 1.6.1 (project pin) lacks the typed 4-arg ServiceCompat.startForeground overload.

* ForegroundNotifier (new, Android-only) — owned by AndroidService in the :qt_service process. Wires to every Device::dataUpdated() through the current DeviceManager, maintains a 6-entry ring buffer, and flushes via a trailing-edge 3 s debounce plus a 10 s periodic tick (so "Xs ago" stays accurate during idle). Value summary uses QObject::property() reflection over known sensor properties (temperature, humidity, co2, voc, pm25, pressure, luminosity, weight, battery) and filters the -99 "no reading" sentinel — no virtuals added to Device subclasses.

* AndroidService now reattaches the notifier on each gotowork() because the cycle destroys/recreates the DeviceManager.

* DeviceManager exposes a one-line public getDeviceList() so the notifier can iterate without findChildren heuristics.

Manifest is unchanged — FOREGROUND_SERVICE_CONNECTED_DEVICE, POST_NOTIFICATIONS, and foregroundServiceType="connectedDevice" were already correct.

Copy on the user-facing surfaces was also reworked so the Play-policy review (and every first-run user) sees the rationale for the location permission and the existence of the persistent notification before the system prompts do:

* qml/Settings.qml — "experimental" red pill on the Background-updates row → neutral "Beta" pill in the primary colour (labelling the feature "experimental" in the same screen that requests an elevated permission undermines the submission). Toggle subtext rewritten to mention the persistent notification + Stop affordance up-front, replacing the jargon-y "predefined interval" and the confusing "Bluetooth (or Bluetooth control)" parenthetical. Switched textFormat to StyledText so the inline <b>Stop</b> renders.

* qml/popups/PopupBackgroundUpdates.qml — permission rationale (locPerm == false branch) now explains why Android demands location for BLE ("an OS-level requirement that applies to all BLE apps. Theengs only reads sensor advertisements; it does not track your location.") and repeats the notification + Stop disclosure so the user sees it in both places. Battery-saver section (locPerm == true branch) drops the adversarial "your phone will do its best to prevent this application from running in the background" framing for "Some Android phones aggressively pause background apps to save battery", names the actual Android control ("battery optimisation") and hedges the autolaunch line so Pixel / Samsung users aren't told to find a toggle their device doesn't have (autolaunch is Xiaomi / OPPO / Huawei territory).

Verified end-to-end on a connected LG H930 (API 28): live body updates, BigText lists active sensors, Stop action terminates :qt_service cleanly (no IllegalStateException, no orphaned scanner). Install + permission grants also confirmed on a Samsung S10 (API 31).

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/app/blob/development/docs/participate/development.md#developer-certificate-of-origin).
