### PR TITLE
Android: request POST_NOTIFICATIONS at runtime so the FGS notificatio…

### DIFF
--- a/assets/android/src/com/theengs/app/TheengsAndroidService.java
+++ b/assets/android/src/com/theengs/app/TheengsAndroidService.java
@@ -18,6 +18,8 @@
 
 package com.theengs.app;
 
+import android.Manifest;
+import android.app.Activity;
 import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
@@ -26,12 +28,15 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.pm.PackageManager;
 import android.content.pm.ServiceInfo;
 import android.os.Build;
 import android.util.Log;
 
+import androidx.core.app.ActivityCompat;
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.ServiceCompat;
+import androidx.core.content.ContextCompat;
 
 import org.qtproject.qt.android.bindings.QtService;
 
@@ -46,6 +51,13 @@ public class TheengsAndroidService extends QtService {
     // receiver. Registered dynamically in onCreate() (RECEIVER_NOT_EXPORTED
     // on API 33+) so we don't need a manifest <receiver> entry.
     private static final String ACTION_STOP_FGS = "com.theengs.app.action.STOP_FGS";
+
+    // Request code for the POST_NOTIFICATIONS runtime-permission dialog
+    // (Android 13+). We don't observe the result here — the foreground
+    // service simply starts posting once Android records the grant — but
+    // the value must be stable so a redelivered onRequestPermissionsResult
+    // wouldn't be mistaken for some other in-flight request.
+    private static final int REQUEST_CODE_POST_NOTIFICATIONS = 1101;
 
     // Live notification content fed from C++ via updateNotification().
     // volatile because the static setter is called from the Qt main thread of
@@ -223,6 +235,43 @@ public class TheengsAndroidService extends QtService {
         } catch (Exception e) {
             Log.e(TAG, "updateNotification failed", e);
         }
+    }
+
+    /**
+     * True when POST_NOTIFICATIONS has been granted (or the OS doesn't gate
+     * it — pre-Android-13 / API &lt; 33 — in which case the manifest
+     * declaration is sufficient and this always returns true).
+     *
+     * Called from C++ (PermissionManager) via JNI auto-linking.
+     */
+    public static boolean isPostNotificationsGranted(Context ctx) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            return true;
+        }
+        return ContextCompat.checkSelfPermission(ctx,
+            Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED;
+    }
+
+    /**
+     * Trigger the system runtime-permission dialog for POST_NOTIFICATIONS.
+     * No-op on Android &lt; 13 (API 33), where the manifest declaration is
+     * sufficient; also no-op when the permission is already granted.
+     *
+     * The dialog is asynchronous and we don't observe the result — the
+     * foreground service starts posting the moment Android records the
+     * grant. Callers that need the result should re-check via
+     * {@link #isPostNotificationsGranted(Context)} after the Activity
+     * resumes.
+     *
+     * Must be invoked with an Activity context;
+     * {@link ActivityCompat#requestPermissions} requires one.
+     */
+    public static void requestPostNotifications(Activity activity) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return;
+        if (isPostNotificationsGranted(activity)) return;
+        ActivityCompat.requestPermissions(activity,
+            new String[]{Manifest.permission.POST_NOTIFICATIONS},
+            REQUEST_CODE_POST_NOTIFICATIONS);
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/src/PermissionManager.cpp
+++ b/src/PermissionManager.cpp
@@ -24,6 +24,11 @@
 #include <QPermission>
 #include <QThread>
 
+#if defined(Q_OS_ANDROID)
+#include <QJniObject>
+#include <QCoreApplication>
+#endif
+
 /* ************************************************************************** */
 /* ************************************************************************** */
 
@@ -104,6 +109,15 @@ void PermissionManager::setMicrophonePermission(bool perm)
     {
         m_microphonePermission = perm;
         Q_EMIT microphonePermissionChanged();
+    }
+}
+
+void PermissionManager::setNotificationPermission(bool perm)
+{
+    if (m_notificationPermission != perm)
+    {
+        m_notificationPermission = perm;
+        Q_EMIT notificationPermissionChanged();
     }
 }
 
@@ -394,6 +408,66 @@ bool PermissionManager::waitLocationPermission()
     }
 
     return m_locationPermission;
+}
+
+/* ************************************************************************** */
+/* ************************************************************************** */
+
+bool PermissionManager::checkNotificationPermission()
+{
+#if defined(Q_OS_ANDROID)
+    // The Java helper handles the SDK_INT < 33 short-circuit and the
+    // ContextCompat.checkSelfPermission call. We only need to thread a
+    // Context across the JNI boundary.
+    QJniObject context = QNativeInterface::QAndroidApplication::context();
+    if (!context.isValid())
+    {
+        setNotificationPermission(false);
+        return m_notificationPermission;
+    }
+
+    jboolean granted = QJniObject::callStaticMethod<jboolean>(
+        "com/theengs/app/TheengsAndroidService",
+        "isPostNotificationsGranted",
+        "(Landroid/content/Context;)Z",
+        context.object<jobject>());
+    setNotificationPermission(granted == JNI_TRUE);
+    return m_notificationPermission;
+#else
+    // No runtime gate on desktop / iOS — the manifest / Info.plist (or
+    // platform defaults) decides; tracking it as ``granted`` keeps QML
+    // bindings uniform across platforms.
+    setNotificationPermission(true);
+    return m_notificationPermission;
+#endif
+}
+
+bool PermissionManager::requestNotificationPermission()
+{
+#if defined(Q_OS_ANDROID)
+    // Skip the round-trip if Android already says yes (covers both
+    // pre-API-33 phones via the helper's SDK_INT check, and any later
+    // call after the user has already granted).
+    if (checkNotificationPermission()) return true;
+
+    QJniObject activity = QNativeInterface::QAndroidApplication::context();
+    if (!activity.isValid()) return false;
+
+    // Asynchronous. The system dialog appears once the Activity is in a
+    // resumed state; the result lands on onRequestPermissionsResult and
+    // the FGS notification starts being painted on the next post. QML
+    // observers re-read the property after Qt.ApplicationActive.
+    qDebug() << "Requesting POST_NOTIFICATIONS permission...";
+    QJniObject::callStaticMethod<void>(
+        "com/theengs/app/TheengsAndroidService",
+        "requestPostNotifications",
+        "(Landroid/app/Activity;)V",
+        activity.object<jobject>());
+    return m_notificationPermission;
+#else
+    setNotificationPermission(true);
+    return m_notificationPermission;
+#endif
 }
 
 /* ************************************************************************** */

--- a/src/PermissionManager.h
+++ b/src/PermissionManager.h
@@ -53,6 +53,11 @@ class PermissionManager: public QObject
     Q_PROPERTY(bool contactsPermission READ hasContactsPermission NOTIFY contactsPermissionChanged)
     Q_PROPERTY(bool locationPermission READ hasLocationPermission NOTIFY locationPermissionChanged)
     Q_PROPERTY(bool microphonePermission READ hasMicrophonePermission NOTIFY microphonePermissionChanged)
+    // Android 13+ (API 33+) POST_NOTIFICATIONS — runtime-gated and required
+    // for the foreground service to post its persistent notification. Qt
+    // 6.10 has no typed QPermission for this, so we go through JNI (the
+    // Java side lives in TheengsAndroidService).
+    Q_PROPERTY(bool notificationPermission READ hasNotificationPermission NOTIFY notificationPermissionChanged)
 
     static PermissionManager *instance;
     PermissionManager();
@@ -67,6 +72,7 @@ class PermissionManager: public QObject
     bool m_contactsPermission = false;
     bool m_locationPermission = false;
     bool m_microphonePermission = false;
+    bool m_notificationPermission = false;
 
     void setBluetoothPermission(bool perm);
     void setCalendarPermission(bool perm);
@@ -74,6 +80,7 @@ class PermissionManager: public QObject
     void setContactsPermission(bool perm);
     void setLocationPermission(bool perm);
     void setMicrophonePermission(bool perm);
+    void setNotificationPermission(bool perm);
 
     void requestBluetoothPermission_results(const QPermission &permission);
     void requestCameraPermission_results(const QPermission &permission);
@@ -86,6 +93,7 @@ Q_SIGNALS:
     void contactsPermissionChanged();
     void locationPermissionChanged();
     void microphonePermissionChanged();
+    void notificationPermissionChanged();
 
 public:
     static PermissionManager *getInstance();
@@ -96,6 +104,7 @@ public:
     bool hasContactsPermission() const { return m_contactsPermission; }
     bool hasLocationPermission() const { return m_locationPermission; }
     bool hasMicrophonePermission() const { return m_microphonePermission; }
+    bool hasNotificationPermission() const { return m_notificationPermission; }
 
     Q_INVOKABLE bool requestBluetoothPermission();
     Q_INVOKABLE bool checkBluetoothPermission();
@@ -108,6 +117,13 @@ public:
     Q_INVOKABLE bool requestLocationPermission();
     Q_INVOKABLE bool checkLocationPermission();
     Q_INVOKABLE bool waitLocationPermission();
+
+    // POST_NOTIFICATIONS request goes through JNI (no typed QPermission
+    // class for it in Qt 6.10). No ``wait`` variant — the dialog is
+    // fire-and-forget and the FGS picks up the grant on its next post
+    // attempt; QML can re-check via the property when the activity resumes.
+    Q_INVOKABLE bool requestNotificationPermission();
+    Q_INVOKABLE bool checkNotificationPermission();
 };
 
 /* ************************************************************************** */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -144,6 +144,17 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 
+#if defined(Q_OS_ANDROID)
+    // Android 13 (API 33) reclassified POST_NOTIFICATIONS as a runtime
+    // permission. Without it the foreground-service notification is
+    // silently dropped (dumpsys reports numPostedByApp=0 despite the FGS
+    // running), so the user can't see / dismiss the App. The helper
+    // no-ops on pre-API-33 phones via Build.VERSION.SDK_INT, so this is
+    // a single unconditional call here. Fire-and-forget — the dialog is
+    // asynchronous and QML re-reads the property on activity resume.
+    pm->requestNotificationPermission();
+#endif
+
     // Runtime-only CLI overrides for MQTT TLS. ``--mqtt-ca <path>`` forces
     // TLS on and sets the CA cert path; ``--mqtt-port <int>`` overrides
     // the port; ``--mqtt-tls-insecure`` skips peer verification (needed


### PR DESCRIPTION
## Description:
Android 13 (API 33) reclassified POST_NOTIFICATIONS from a manifest-only permission to a runtime permission. The App's manifest already declares it (with android:minSdkVersion="33"), but nothing in PermissionManager or DeviceManager was asking for it at runtime, so on Android 13+ phones the foreground-service notification was silently suppressed:

  - dumpsys activity services com.theengs.app  → isForeground=true
  - dumpsys notification | grep theengs        → numEnqueuedByApp=NNN
                                                  numPostedByApp=0

The FGS itself runs fine (BLE scanning + MQTT publish continue), but the user can't see or dismiss the App from the status bar, and the FOREGROUND_SERVICE_CONNECTED_DEVICE policy expects a visible notification.

Qt 6.10 has no typed QPermission for notifications (only Bluetooth / Calendar / Camera / Contacts / Location / Microphone are in the typed set), so the check + request go through JNI to two new static helpers in TheengsAndroidService.java:

  - isPostNotificationsGranted(Context) — short-circuits true on API < 33
  - requestPostNotifications(Activity)  — fire-and-forget; the FGS picks up the grant on its next post

PermissionManager mirrors the existing per-permission pattern (Q_PROPERTY + setter + signal + Q_INVOKABLE check/request), and main.cpp calls pm->requestNotificationPermission() once at startup inside #if defined(Q_OS_ANDROID). The helper's SDK_INT guard makes this a no-op on older phones, so no version-test is needed C++-side.

Verified on a Samsung Galaxy S20 FE (SM-G781U1, Android 13, API 33, arm64-v8a): pre-patch, the system runtime dialog never appears and the FGS notification is invisible; post-patch, the dialog appears on first launch, the user grants, and the FGS notification is painted normally.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/app/blob/development/docs/participate/development.md#developer-certificate-of-origin).
