### PR TITLE
CI: restore iOS Xcode 26 SDK fix reverted by #125

### DIFF
--- a/.github/workflows/builds_mobile.yml
+++ b/.github/workflows/builds_mobile.yml
@@ -291,7 +291,10 @@ jobs:
   ## iOS build #################################################################
   build-ios:
     name: "iOS CI build"
-    runs-on: macos-15
+    # macos-latest tracks GitHub's current macOS image and ships the most recent
+    # Xcode. App Store Connect now requires builds against the iOS 26 SDK
+    # (Xcode 26+); macos-15 with Xcode 16.x is rejected at upload validation.
+    runs-on: macos-latest
     env:
       DISTRIBUTE: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/development' || startsWith(github.ref, 'refs/tags/v')) && github.repository == 'theengs/app' }}
       REPO_NAME: ${{ github.event.repository.name }}
@@ -301,6 +304,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      # Pin Xcode to the latest stable version available on the runner so
+      # builds are reproducible and we get the iOS 26+ SDK that App Store
+      # Connect now requires for uploads.
+      - name: Select latest Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
 
       # Install Qt (desktop & iOS)
       - name: Install Qt (desktop & iOS)


### PR DESCRIPTION
## Description:
#123 (commit 463581e) switched the iOS job to macos-latest + an explicit setup-xcode latest-stable step so builds picked up the Xcode 26 / iOS 26 SDK that App Store Connect now mandates. #125 (commit da8a7d5) was branched from a base that predated #123, so its merge silently restored the old runs-on: macos-15 and removed the setup-xcode step, breaking the iOS upload again ("SDK version issue").

Re-apply #123 verbatim; the Android ABI work from #125 is unaffected.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/app/blob/development/docs/participate/development.md#developer-certificate-of-origin).
