### PR TITLE
Feat/ux mqtt sentinels sampling caption

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,6 +201,7 @@ qt_add_qml_module(${CMAKE_PROJECT_NAME}
         qml/components/ItemNoBluetooth.qml
         qml/components/ItemNoPermissions.qml
         qml/components/ItemNoData.qml
+        qml/components/ItemSamplingCaption.qml
         qml/components/ItemNoDevice.qml
         qml/components/ItemNoDeviceNearby.qml
         qml/components/ItemNoGateway.qml

--- a/qml/DeviceEnvironmental.qml
+++ b/qml/DeviceEnvironmental.qml
@@ -1111,7 +1111,8 @@ Loader {
                         Loader {
                             id: chartEnvLoader
                             width: parent.width
-                            height: (sensorFlick.height - airBoxes.height - weatherBoxes.height)
+                            height: (sensorFlick.height - airBoxes.height - weatherBoxes.height
+                                     - envSamplingCaption.implicitHeight)
                             //height: singleColumn ? 360 : (sensorFlick.height - airBox.height - weatherBox.height)
 
                             asynchronous: true
@@ -1119,6 +1120,12 @@ Loader {
                                 historyChart.loadGraph()
                                 historyChart.updateGraph()
                             }
+                        }
+
+                        ItemSamplingCaption {
+                            id: envSamplingCaption
+                            width: parent.width
+                            intervalMin: settingsManager.updateIntervalEnv
                         }
 
                         ////////////////////////////////////////////////////

--- a/qml/DeviceList.qml
+++ b/qml/DeviceList.qml
@@ -228,6 +228,71 @@ Item {
 
         ////////////////
 
+        // MQTT-down banner. Only shown when the user has MQTT enabled but the
+        // client is not connected — silences the broker badge for users who
+        // never configured MQTT in the first place. Auto-collapses on reconnect.
+        Rectangle {
+            id: rectangleMqttStatus
+            anchors.left: parent.left
+            anchors.right: parent.right
+
+            readonly property bool mqttDown: (settingsManager.mqtt && !mqttManager.status)
+            height: mqttDown ? 48 : 0
+            Behavior on height { NumberAnimation { duration: 133 } }
+
+            clip: true
+            visible: (height > 0)
+            color: Theme.colorActionbar
+
+            // prevent clicks below this area
+            MouseArea { anchors.fill: parent; acceptedButtons: Qt.AllButtons }
+
+            Text {
+                id: textMqttStatus
+                anchors.left: parent.left
+                anchors.leftMargin: 16
+                anchors.right: buttonMqttStatus.left
+                anchors.rightMargin: 8
+                anchors.verticalCenter: parent.verticalCenter
+
+                color: Theme.colorActionbarContent
+                verticalAlignment: Text.AlignVCenter
+                horizontalAlignment: Text.AlignLeft
+                elide: Text.ElideRight
+                font.bold: isDesktop ? true : false
+                font.pixelSize: Theme.componentFontSize
+
+                // Re-evaluate whenever drop counter or status moves.
+                text: {
+                    let n = mqttManager.droppedSinceDisconnect
+                    let since = mqttManager.disconnectedSince
+                    let sinceStr = (since && since.getTime && since.getTime() > 0)
+                                   ? Qt.formatTime(since, "HH:mm") : ""
+                    if (n > 0 && sinceStr) {
+                        return qsTr("MQTT not connected — %1 readings lost since %2")
+                               .arg(n).arg(sinceStr)
+                    } else if (sinceStr) {
+                        return qsTr("MQTT not connected since %1").arg(sinceStr)
+                    }
+                    return qsTr("MQTT not connected")
+                }
+            }
+
+            ButtonSolid {
+                id: buttonMqttStatus
+                anchors.right: parent.right
+                anchors.rightMargin: 16
+                anchors.verticalCenter: parent.verticalCenter
+                height: 32
+
+                color: Theme.colorActionbarHighlight
+                text: qsTr("Retry")
+                onClicked: mqttManager.reconnect_forced()
+            }
+        }
+
+        ////////////////
+
         Rectangle {
             id: rectangleActions
             anchors.left: parent.left

--- a/qml/DevicePlantSensorData.qml
+++ b/qml/DevicePlantSensorData.qml
@@ -437,7 +437,10 @@ Item {
 
             Loader {
                 id: chartAioLoader
-                anchors.fill: parent
+                anchors.top: parent.top
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.bottom: samplingCaption.top
 
                 opacity: 0
                 Behavior on opacity { OpacityAnimator { duration: 133 } }
@@ -449,6 +452,14 @@ Item {
                     dataChart.updateGraph()
                     chartAioLoader.opacity = 1
                 }
+            }
+
+            ItemSamplingCaption {
+                id: samplingCaption
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.bottom: parent.bottom
+                intervalMin: settingsManager.updateIntervalPlant
             }
         }
     }

--- a/qml/DeviceThermometer.qml
+++ b/qml/DeviceThermometer.qml
@@ -504,7 +504,7 @@ Loader {
                     anchors.top: bannersync.bottom
                     anchors.left: parent.left
                     anchors.right: parent.right
-                    anchors.bottom: parent.bottom
+                    anchors.bottom: samplingCaption.top
 
                     active: deviceThermometer.visible
                     asynchronous: true
@@ -515,6 +515,14 @@ Loader {
                         graphLoader.opacity = 1
                         noDataIndicator.visible = (currentDevice.countDataNamed("temperature", thermoChart.daysVisible) < 1)
                     }
+                }
+
+                ItemSamplingCaption {
+                    id: samplingCaption
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.bottom: parent.bottom
+                    intervalMin: settingsManager.updateIntervalThermo
                 }
             }
         }

--- a/qml/components/ItemSamplingCaption.qml
+++ b/qml/components/ItemSamplingCaption.qml
@@ -1,0 +1,40 @@
+import QtQuick
+import QtQuick.Controls
+
+import ComponentLibrary
+
+// Small footer caption shown under in-app history charts. Reminds the user
+// that what the chart shows is sampled at the per-category interval from
+// Settings, so the HA/broker timeseries (every advert) may differ. Tapping
+// the text takes them to Settings.
+//
+// Required property: intervalMin (uint, minutes). Pass the relevant
+// settingsManager.updateInterval{Thermo,Plant,Env} from the parent screen.
+
+Item {
+    id: itemSamplingCaption
+
+    property int intervalMin: 0
+
+    implicitHeight: visible ? captionText.implicitHeight + 8 : 0
+    visible: (intervalMin > 0)
+
+    Text {
+        id: captionText
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.verticalCenter: parent.verticalCenter
+
+        textFormat: Text.PlainText
+        color: Theme.colorSubText
+        opacity: 0.75
+        font.pixelSize: Theme.fontSizeContentVerySmall
+        font.italic: true
+        horizontalAlignment: Text.AlignHCenter
+
+        text: qsTr("1 sample / %1 min \u00b7 change in Settings").arg(intervalMin)
+    }
+
+    // No MouseArea / "tap to open Settings" wiring yet — the screen-routing
+    // pattern differs between Desktop and Mobile entry points, and a passive
+    // caption beats wiring a half-working tap target.
+}

--- a/qml/components/ItemSamplingCaption.qml
+++ b/qml/components/ItemSamplingCaption.qml
@@ -4,12 +4,15 @@ import QtQuick.Controls
 import ComponentLibrary
 
 // Small footer caption shown under in-app history charts. Reminds the user
-// that what the chart shows is sampled at the per-category interval from
-// Settings, so the HA/broker timeseries (every advert) may differ. Tapping
-// the text takes them to Settings.
+// that what the chart shows is sampled at the per-category interval, which
+// can diverge from the broker timeseries (every advert).
 //
 // Required property: intervalMin (uint, minutes). Pass the relevant
 // settingsManager.updateInterval{Thermo,Plant,Env} from the parent screen.
+//
+// NB: the interval setters exist in C++ (SettingsManager::setUpdateInterval*)
+// but no QML Settings control is wired to them today, so the caption is
+// purely informational — no "change in Settings" cue, which would mislead.
 
 Item {
     id: itemSamplingCaption
@@ -31,10 +34,6 @@ Item {
         font.italic: true
         horizontalAlignment: Text.AlignHCenter
 
-        text: qsTr("1 sample / %1 min \u00b7 change in Settings").arg(intervalMin)
+        text: qsTr("1 sample / %1 min").arg(intervalMin)
     }
-
-    // No MouseArea / "tap to open Settings" wiring yet — the screen-routing
-    // pattern differs between Desktop and Mobile entry points, and a passive
-    // caption beats wiring a half-working tap target.
 }

--- a/qml/widgets/DeviceWidget.qml
+++ b/qml/widgets/DeviceWidget.qml
@@ -665,9 +665,14 @@ Item {
 
             function initData() { }
 
+            // Device subclasses default temperature/humidity to -99 to mean
+            // "no reading yet" (see device_sensor.h). The list-row rendered
+            // raw, so transient/just-discovered devices showed "-99.0°" until
+            // a real frame arrived. Guard with the same -40 threshold the
+            // detail screens use.
             function updateData() {
                 if (boxDevice.isThermometer) {
-                    valueText.text = boxDevice.temperature.toFixed(1)
+                    valueText.text = (boxDevice.temperature > -40) ? boxDevice.temperature.toFixed(1) : "—"
                     unitText.text = "°"
                 } else if (boxDevice.isEnvironmentalSensor) {
                     if (boxDevice.hasGeigerCounter) {
@@ -678,7 +683,7 @@ Item {
                     valueText.text = (settingsManager.tempUnit === 'C') ? boxDevice.weight.toFixed(1) : (boxDevice.weight * 2.20462).toFixed(1)
                     unitText.text = (settingsManager.tempUnit === 'C') ? qsTr("kg") : qsTr("lb")
                 } else if (boxDevice.isGenericDevice) {
-                    valueText.text = boxDevice.temperature.toFixed(1)
+                    valueText.text = (boxDevice.temperature > -40) ? boxDevice.temperature.toFixed(1) : "—"
                     unitText.text = "°"
                 }
             }
@@ -731,8 +736,9 @@ Item {
 
             function updateData() {
                 if (boxDevice.isThermometer) {
-                    textOne.text = boxDevice.temperature.toFixed(1) + "°"
+                    textOne.text = (boxDevice.temperature > -40) ? (boxDevice.temperature.toFixed(1) + "°") : "—"
                     if (boxDevice.humidity > 0) textTwo.text = boxDevice.humidity.toFixed(0) + "%"
+                    else textTwo.text = ""
                 } else if (boxDevice.isEnvironmentalSensor) {
                     //
                 } else if (boxDevice.isScale) {
@@ -763,8 +769,8 @@ Item {
                 } else if (boxDevice.isProbe) {
                     //
                 } else {
-                    textOne.text = boxDevice.temperature.toFixed(1) + "°"
-                    textTwo.text = boxDevice.humidity.toFixed(0) + "%"
+                    textOne.text = (boxDevice.temperature > -40) ? (boxDevice.temperature.toFixed(1) + "°") : "—"
+                    textTwo.text = (boxDevice.humidity > 0) ? (boxDevice.humidity.toFixed(0) + "%") : ""
                 }
             }
 

--- a/src/DeviceManager_advertisement.cpp
+++ b/src/DeviceManager_advertisement.cpp
@@ -344,8 +344,12 @@ void DeviceManager::bleDevice_updated(const QBluetoothDeviceInfo &info, QBluetoo
 
                 decoded = true;
 
-                // Do not process devices with random macs
-                if (doc["type"] == "RMAC" || doc["prmac"]) break;
+                // Drop random-MAC frames AND iBeacon broadcasts. The known-
+                // device path filters all three at line 203; keep them in
+                // sync here so the unknown branch can't quietly republish
+                // iBeacon adverts to MQTT.
+                if (doc["type"] == "RMAC" || doc["prmac"] ||
+                    doc["model_id"] == "IBEACON") break;
 
                 obj.remove("manufacturerdata");
                 obj.remove("servicedata");

--- a/src/ForegroundNotifier.cpp
+++ b/src/ForegroundNotifier.cpp
@@ -23,6 +23,8 @@
 #include "DeviceManager.h"
 #include "DeviceFilter.h"
 #include "device.h"
+#include "MqttManager.h"
+#include "SettingsManager.h"
 
 #include <QJniObject>
 #include <QStringList>
@@ -75,6 +77,14 @@ ForegroundNotifier::ForegroundNotifier(QObject *parent) : QObject(parent)
     m_refresh.setInterval(kRefreshMs);
     connect(&m_refresh, &QTimer::timeout, this, &ForegroundNotifier::flush);
     m_refresh.start();
+
+    // Repaint the notification immediately on MQTT state/drop changes so the
+    // "MQTT down — N lost" annotation appears without waiting for the 10 s
+    // refresh tick. MqttManager is a per-process singleton in :qt_service.
+    if (MqttManager *mq = MqttManager::getInstance()) {
+        connect(mq, &MqttManager::statusChanged,  this, &ForegroundNotifier::flush);
+        connect(mq, &MqttManager::droppedChanged, this, &ForegroundNotifier::flush);
+    }
 }
 
 ForegroundNotifier::~ForegroundNotifier() = default;
@@ -214,6 +224,25 @@ void ForegroundNotifier::pushUpdate()
     if (active < 1) active = m_recent.size();
 
     const QDateTime &mostRecent = m_recent.first().when;
+
+    // MQTT-down annotation: only when the user actually opted into MQTT but
+    // the broker link is down. Silent for users who never configured MQTT.
+    QString mqttSuffix;
+    {
+        SettingsManager *sm = SettingsManager::getInstance();
+        MqttManager *mq = MqttManager::getInstance();
+        if (sm && sm->getMQTT() && mq && !mq->getStatus())
+        {
+            const qint64 dropped = mq->getDroppedSinceDisconnect();
+            if (dropped > 0) {
+                mqttSuffix = QStringLiteral(" \u00b7 ") +
+                             tr("MQTT down \u2013 %1 lost").arg(dropped);
+            } else {
+                mqttSuffix = QStringLiteral(" \u00b7 ") + tr("MQTT down");
+            }
+        }
+    }
+
     const QString title = tr("Theengs \u00b7 Scanning Bluetooth sensors");
     // Qt's tr("%n …", n) plural form only switches catalogues when one is
     // loaded; with no Android-side translation catalog, %n leaves "(s)"
@@ -222,7 +251,7 @@ void ForegroundNotifier::pushUpdate()
     const QString body = tr("%1 %2 active \u00b7 last reading %3")
                          .arg(active)
                          .arg(sensorWord)
-                         .arg(relativeAge(mostRecent, now));
+                         .arg(relativeAge(mostRecent, now)) + mqttSuffix;
 
     QStringList lines;
     lines.reserve(m_recent.size());

--- a/src/MqttManager.cpp
+++ b/src/MqttManager.cpp
@@ -238,6 +238,18 @@ bool MqttManager::publishData(QString topic, QString str)
         m_mqttclient->publish(t, m);
         return true;
     }
+
+    // Track drops while disconnected so the UI can surface "MQTT down — N
+    // readings lost since HH:MM". Only count when MQTT is *configured* on,
+    // otherwise an opted-out user would see scary counters.
+    SettingsManager *sm = SettingsManager::getInstance();
+    if (sm && sm->getMQTT())
+    {
+        ++m_droppedSinceDisconnect;
+        Q_EMIT droppedChanged();
+    }
+#else
+    Q_UNUSED(topic) Q_UNUSED(str)
 #endif
 
     return false;
@@ -296,6 +308,19 @@ void MqttManager::brokerConnected()
 
     if (m_mqttclient)
     {
+        // Clear drop bookkeeping: the banner/notification hides automatically
+        // once droppedSinceDisconnect == 0 and disconnectedSince is invalid.
+        if (m_droppedSinceDisconnect != 0)
+        {
+            m_droppedSinceDisconnect = 0;
+            Q_EMIT droppedChanged();
+        }
+        if (m_disconnectedSince.isValid())
+        {
+            m_disconnectedSince = QDateTime();
+            // statusChanged already emitted by updateStateChange().
+        }
+
         Q_EMIT connected();
 
         SettingsManager *sm = SettingsManager::getInstance();
@@ -335,6 +360,13 @@ void MqttManager::brokerConnected()
 void MqttManager::brokerDisconnected()
 {
     //qDebug() << "MqttManager::brokerDisconnected()";
+
+    // Stamp the moment the link went down so UI can show "since HH:MM".
+    // updateStateChange() will fire statusChanged separately.
+    if (!m_disconnectedSince.isValid())
+    {
+        m_disconnectedSince = QDateTime::currentDateTime();
+    }
 }
 
 void MqttManager::handleMessage(/*const QMqttMessage &qmsg*/)

--- a/src/MqttManager.h
+++ b/src/MqttManager.h
@@ -24,6 +24,7 @@
 #include <QString>
 #include <QVariant>
 #include <QList>
+#include <QDateTime>
 
 #if defined(ENABLE_MQTT)
 #include <QtMqtt/QtMqtt>
@@ -95,6 +96,12 @@ class MqttManager: public QObject
 
     Q_PROPERTY(bool status READ getStatus NOTIFY statusChanged)
 
+    // Count of publishData() calls dropped because the client wasn't Connected.
+    // Resets to 0 when the broker comes back. Surfaced in the device list and
+    // foreground notification so users know data is being lost.
+    Q_PROPERTY(qint64 droppedSinceDisconnect READ getDroppedSinceDisconnect NOTIFY droppedChanged)
+    Q_PROPERTY(QDateTime disconnectedSince READ getDisconnectedSince NOTIFY statusChanged)
+
     Q_PROPERTY(QString log READ getLog NOTIFY logChanged) // DEBUG
 
     Q_PROPERTY(QVariant brokersAvailable READ getBrokersAvailable NOTIFY brokersUpdated)
@@ -104,6 +111,10 @@ class MqttManager: public QObject
 #endif
 
     QString m_mqttLog; // DEBUG
+
+    // Dropped-message bookkeeping. Updated from publishData() / state handlers.
+    qint64 m_droppedSinceDisconnect = 0;
+    QDateTime m_disconnectedSince;
 
     QList <Broker *> m_brokersAvailable;
     QVariant getBrokersAvailable() const { return QVariant::fromValue(m_brokersAvailable); }
@@ -116,6 +127,7 @@ class MqttManager: public QObject
 Q_SIGNALS:
     void brokersUpdated();
     void statusChanged();
+    void droppedChanged();
     void logChanged();
     void connected();
 
@@ -144,6 +156,8 @@ public:
     bool subscribe(QString topic);
 
     bool getStatus() const;
+    qint64 getDroppedSinceDisconnect() const { return m_droppedSinceDisconnect; }
+    QDateTime getDisconnectedSince() const { return m_disconnectedSince; }
 
     QString getLog() const { return m_mqttLog; }
 };


### PR DESCRIPTION
  ## Summary

  Three small, additive UX wins from auditing the data flow of a single BLE advertisement (which fans out to four sinks: phone SQLite, MQTT broker, Android notification, QML display) — and finding cases where they fall silently out of sync.

  ### 1. MQTT-down is no longer silent (`4b1ede1`)
  - `MqttManager`: new `droppedSinceDisconnect` counter and `disconnectedSince` timestamp, only counted when MQTT is *configured* on (opt-out users see nothing). Both reset on reconnect.
  - Device list: collapsing green banner "MQTT not connected — N readings lost since HH:MM" with Retry, auto-hides when the broker comes back.
  - Android FGS notification body gets a "MQTT down – N lost" suffix. `ForegroundNotifier` listens to `statusChanged`/`droppedChanged` so it repaints immediately rather than waiting for its 10 s refresh tick.

  ### 2. Sentinel filtering is consistent across sinks (`4966935`)
  - `DeviceManager_advertisement.cpp:343` (unknown-device path) now drops `model_id == "IBEACON"`, mirroring the known-device path at :203. Previously iBeacon adverts from not-yet-paired devices were silently republished to MQTT.
  - `DeviceWidget.qml` list rows guard temperature `> -40` and humidity `> 0` and render `—` instead of `-99.0°` between BLE discovery and first decode (matches the detail-screen idiom).

  ### 3. Chart sampling-interval caption (`2f8fb70`, `a4190d4`)
  - New `qml/components/ItemSamplingCaption.qml`, wired into Thermometer / PlantSensor / Environmental detail screens. Reads `settingsManager.updateInterval{Thermo,Plant,Env}` (defaults 120 / 240 / 60 min from `SettingsManager.h`).
  - Shows "1 sample / N min" under the chart so users understand why the in-app history is coarser than the broker timeseries (every advert).
  - The C++ setters exist but no QML Settings control is wired to them today, so the caption is informational only — no misleading "change in Settings" cue.

  ## Why this came up

  Audit traced one advert through `MqttManager::publishData`, `DeviceTheengs::needsUpdateDb`, `ForegroundNotifier`, and the QML list model. Several gates differ across paths (sentinel filters, IBEACON filter asymmetry, DB rate-limiting, silent MQTT drop). This PR ships the cheap, user-visible wins.
  Bigger items — `isEnabled()` should gate the publish path too, MQTT topic instability across the known/unknown boundary — are left for separate discussion.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/app/blob/development/docs/participate/development.md#developer-certificate-of-origin).
