### PR TITLE
Feat/credential secure storage

### DIFF
--- a/.github/workflows/builds_desktop.yml
+++ b/.github/workflows/builds_desktop.yml
@@ -39,6 +39,7 @@ jobs:
              sudo apt-get install libgl1-mesa-dev libxkbcommon-x11-dev libx11-xcb-dev libzstd-dev -y;
              sudo apt-get install cmake ninja-build pkgconf libtool -y;
              sudo apt-get install libfuse2 appstream -y;
+             sudo apt-get install libsecret-1-dev -y;   # QtKeychain Linux backend (secure storage)
 
       # Install Qt
       - name: Install Qt

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "thirdparty/TheengsDecoder"]
 	path = thirdparty/TheengsDecoder
 	url = git@github.com:theengs/decoder.git
+[submodule "thirdparty/qtkeychain"]
+	path = thirdparty/qtkeychain
+	url = https://github.com/frankosterfeld/qtkeychain.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -332,6 +332,7 @@ if(ENABLE_SECURE_STORAGE)
     # NOTE: Linux build hosts need libsecret headers (e.g. libsecret-1-dev) for the
     # Linux backend; not required on Android (Keystore) or Apple (Keychain).
     set(BUILD_WITH_QT6 ON CACHE BOOL "" FORCE)          # qtkeychain builds against Qt5 unless this is set
+    set(BUILD_TESTING OFF CACHE BOOL "" FORCE)          # skip qtkeychain's autotest (fails to link on iOS)
     set(BUILD_TEST_APPLICATION OFF CACHE BOOL "" FORCE)
     set(BUILD_TRANSLATIONS OFF CACHE BOOL "" FORCE)
     set(QTKEYCHAIN_STATIC ON CACHE BOOL "" FORCE)       # static; scopes BUILD_SHARED_LIBS to the subdir

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -331,6 +331,7 @@ if(ENABLE_SECURE_STORAGE)
     # included as <qtkeychain/keychain.h>.
     # NOTE: Linux build hosts need libsecret headers (e.g. libsecret-1-dev) for the
     # Linux backend; not required on Android (Keystore) or Apple (Keychain).
+    set(BUILD_WITH_QT6 ON CACHE BOOL "" FORCE)          # qtkeychain builds against Qt5 unless this is set
     set(BUILD_TEST_APPLICATION OFF CACHE BOOL "" FORCE)
     set(BUILD_TRANSLATIONS OFF CACHE BOOL "" FORCE)
     set(QTKEYCHAIN_STATIC ON CACHE BOOL "" FORCE)       # static; scopes BUILD_SHARED_LIBS to the subdir

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ set(APP_VERSION ${CMAKE_PROJECT_VERSION})
 option(ENABLE_MQTT "MQTT broker support" ON)
 option(ENABLE_OPENSSL "OpenSSL for various encryption needs" ON)
 option(ENABLE_MBEDTLS "mbedTLS for various encryption needs" ON)
+option(ENABLE_SECURE_STORAGE "Store MQTT/MySQL passwords in the OS secure store via QtKeychain" ON)
 
 ################################################################################
 
@@ -316,6 +317,29 @@ if(ENABLE_MBEDTLS)
     #set(MbedTLS_DIR ${CMAKE_SOURCE_DIR}/contribs/env/${CONTRIBS_ARCH}/usr/lib/cmake/MbedTLS)
     #find_package(MbedTLS REQUIRED)
     #target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE MbedTLS::mbedtls)
+endif()
+
+if(ENABLE_SECURE_STORAGE)
+    # QtKeychain: stores credentials in the OS secure store rather than plaintext
+    # QSettings. Backends: Keychain (macOS/iOS), Credential Store (Windows),
+    # libsecret/KWallet (Linux), Android Keystore (Android). Bundled as a submodule.
+    #
+    # Pinned to qtkeychain 0.15.0 (earliest release that builds on Qt 6.8+ Android;
+    # 0.14.0's keychain_android.cpp fails to cast QtJniTypes::Context to jobject).
+    # Android Keystore is implemented in C++/JNI so no extra Java/Gradle glue is
+    # needed. The target propagates its own (build-tree) include dir; headers are
+    # included as <qtkeychain/keychain.h>.
+    # NOTE: Linux build hosts need libsecret headers (e.g. libsecret-1-dev) for the
+    # Linux backend; not required on Android (Keystore) or Apple (Keychain).
+    set(BUILD_TEST_APPLICATION OFF CACHE BOOL "" FORCE)
+    set(BUILD_TRANSLATIONS OFF CACHE BOOL "" FORCE)
+    set(QTKEYCHAIN_STATIC ON CACHE BOOL "" FORCE)       # static; scopes BUILD_SHARED_LIBS to the subdir
+    add_subdirectory(thirdparty/qtkeychain)
+
+    target_sources(${CMAKE_PROJECT_NAME} PRIVATE
+        src/utils/SecretStore.cpp src/utils/SecretStore.h)
+    target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE qt6keychain)
+    target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE ENABLE_SECURE_STORAGE)
 endif()
 
 ################################################################################

--- a/src/SettingsManager.cpp
+++ b/src/SettingsManager.cpp
@@ -19,6 +19,13 @@
 #include "SettingsManager.h"
 #include "SystrayManager.h"
 
+#ifdef ENABLE_SECURE_STORAGE
+#include "utils/SecretStore.h"
+//! Keys under which broker/database passwords live in the OS secure store.
+static const QString kMqttPasswordKey = QStringLiteral("mqtt_password");
+static const QString kMysqlPasswordKey = QStringLiteral("mysql_password");
+#endif
+
 #if defined(Q_OS_ANDROID)
 #include "AndroidService.h"
 #endif
@@ -188,8 +195,21 @@ bool SettingsManager::readSettings()
             m_mysqlName = settings.value("database/name").toString();
         if (settings.contains("database/user"))
             m_mysqlUser = settings.value("database/user").toString();
+#ifdef ENABLE_SECURE_STORAGE
+        // Password lives in the OS secure store, never in QSettings. Migrate any
+        // legacy plaintext value written by older versions, then purge it.
+        m_mysqlPassword = SecretStore::readSync(kMysqlPasswordKey);
+        if (m_mysqlPassword.isEmpty() && settings.contains("database/password"))
+        {
+            m_mysqlPassword = settings.value("database/password").toString();
+            if (!m_mysqlPassword.isEmpty())
+                SecretStore::write(kMysqlPasswordKey, m_mysqlPassword);
+        }
+        settings.remove("database/password");
+#else
         if (settings.contains("database/password"))
             m_mysqlPassword = settings.value("database/password").toString();
+#endif
 
         if (settings.contains("mqtt/enabled"))
             m_mqtt = settings.value("mqtt/enabled").toBool();
@@ -203,8 +223,21 @@ bool SettingsManager::readSettings()
             m_mqttName = settings.value("mqtt/name").toString();
         if (settings.contains("mqtt/user"))
             m_mqttUser = settings.value("mqtt/user").toString();
+#ifdef ENABLE_SECURE_STORAGE
+        // Password lives in the OS secure store, never in QSettings. Migrate any
+        // legacy plaintext value written by older versions, then purge it.
+        m_mqttPassword = SecretStore::readSync(kMqttPasswordKey);
+        if (m_mqttPassword.isEmpty() && settings.contains("mqtt/password"))
+        {
+            m_mqttPassword = settings.value("mqtt/password").toString();
+            if (!m_mqttPassword.isEmpty())
+                SecretStore::write(kMqttPasswordKey, m_mqttPassword);
+        }
+        settings.remove("mqtt/password");
+#else
         if (settings.contains("mqtt/password"))
             m_mqttPassword = settings.value("mqtt/password").toString();
+#endif
         if (settings.contains("mqtt/topic_a"))
             m_mqttTopicA = settings.value("mqtt/topic_a").toString();
         if (settings.contains("mqtt/topic_b"))
@@ -263,7 +296,9 @@ bool SettingsManager::writeSettings()
         settings.setValue("database/port", m_mysqlPort);
         settings.setValue("database/name", m_mysqlName);
         settings.setValue("database/user", m_mysqlUser);
+#ifndef ENABLE_SECURE_STORAGE
         settings.setValue("database/password", m_mysqlPassword);
+#endif
 
         settings.setValue("mqtt/enabled", m_mqtt);
         settings.setValue("mqtt/discovery", m_mqttDiscovery);
@@ -271,7 +306,9 @@ bool SettingsManager::writeSettings()
         settings.setValue("mqtt/port", m_mqttPort);
         settings.setValue("mqtt/name", m_mqttName);
         settings.setValue("mqtt/user", m_mqttUser);
+#ifndef ENABLE_SECURE_STORAGE
         settings.setValue("mqtt/password", m_mqttPassword);
+#endif
         settings.setValue("mqtt/topic_a", m_mqttTopicA);
         settings.setValue("mqtt/topic_b", m_mqttTopicB);
         settings.setValue("mqtt/tls", m_mqttTls);
@@ -361,8 +398,8 @@ void SettingsManager::resetSettings()
     m_mysqlHost = "";
     m_mysqlPort = 3306;
     m_mysqlName = "theengs";
-    m_mysqlUser = "theengs";
-    m_mysqlPassword = "theengs";
+    m_mysqlUser = "";
+    m_mysqlPassword = "";
     Q_EMIT mysqlChanged();
 
     m_mqtt = false;
@@ -370,8 +407,8 @@ void SettingsManager::resetSettings()
     m_mqttHost = "";
     m_mqttPort = 1883;
     m_mqttName = "theengs";
-    m_mqttUser = "theengs";
-    m_mqttPassword = "theengs";
+    m_mqttUser = "";
+    m_mqttPassword = "";
     m_mqttTopicA = "home";
     m_mqttTopicB = "TheengsApp";
     m_mqttTls = false;
@@ -682,7 +719,12 @@ void SettingsManager::setMysqlPassword(const QString &value)
     if (m_mysqlPassword != value)
     {
         m_mysqlPassword = value;
+#ifdef ENABLE_SECURE_STORAGE
+        if (value.isEmpty()) SecretStore::remove(kMysqlPasswordKey);
+        else SecretStore::write(kMysqlPasswordKey, value);
+#else
         writeSettings();
+#endif
         Q_EMIT mysqlChanged();
     }
 }
@@ -742,7 +784,12 @@ void SettingsManager::setMqttPassword(const QString &value)
     if (m_mqttPassword != value)
     {
         m_mqttPassword = value;
+#ifdef ENABLE_SECURE_STORAGE
+        if (value.isEmpty()) SecretStore::remove(kMqttPasswordKey);
+        else SecretStore::write(kMqttPasswordKey, value);
+#else
         writeSettings();
+#endif
         Q_EMIT mqttChanged();
     }
 }

--- a/src/SettingsManager.h
+++ b/src/SettingsManager.h
@@ -123,16 +123,16 @@ class SettingsManager: public QObject
     QString m_mysqlHost;
     int m_mysqlPort = 3306;
     QString m_mysqlName = "theengs";
-    QString m_mysqlUser = "theengs";
-    QString m_mysqlPassword = "theengs";
+    QString m_mysqlUser;        //!< no shipped default: empty == "not configured"
+    QString m_mysqlPassword;    //!< no shipped default; resolved from secure storage at runtime
 
     bool m_mqtt = false;
     bool m_mqttDiscovery = true;
     QString m_mqttHost;
     int m_mqttPort = 1883;
     QString m_mqttName = "theengs";
-    QString m_mqttUser = "theengs";
-    QString m_mqttPassword = "theengs";
+    QString m_mqttUser;         //!< no shipped default: empty == anonymous / "not configured"
+    QString m_mqttPassword;     //!< no shipped default; resolved from secure storage at runtime
     QString m_mqttTopicA = "home";
     QString m_mqttTopicB = "TheengsApp";
     bool m_mqttTls = false;

--- a/src/utils/SecretStore.cpp
+++ b/src/utils/SecretStore.cpp
@@ -1,0 +1,82 @@
+/*
+    Theengs - Decode things and devices
+    Copyright: (c) Florian ROBERT
+
+    This file is part of Theengs.
+
+    Theengs is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    Theengs is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "utils/SecretStore.h"
+
+#include <QCoreApplication>
+#include <QEventLoop>
+#include <QDebug>
+
+#include <qtkeychain/keychain.h>
+
+using namespace QKeychain;
+
+/* ************************************************************************** */
+
+QString SecretStore::service()
+{
+    return QStringLiteral("Theengs");
+}
+
+QString SecretStore::readSync(const QString &key)
+{
+    ReadPasswordJob job(service());
+    job.setAutoDelete(false);
+    job.setKey(key);
+
+    // Startup runs before the main event loop, so drive a local one until the
+    // keychain job reports finished. This keeps readSync() synchronous so the
+    // secret is in memory before the first MQTT/MySQL connection attempt.
+    bool finished = false;
+    QObject::connect(&job, &Job::finished, &job, [&finished](Job *) { finished = true; });
+    job.start();
+    while (!finished)
+        QCoreApplication::processEvents(QEventLoop::WaitForMoreEvents, 50);
+
+    if (job.error())
+    {
+        // EntryNotFound is expected on a fresh install / after deletion.
+        if (job.error() != QKeychain::EntryNotFound)
+            qWarning() << "SecretStore::readSync(" << key << ") failed:" << job.errorString();
+        return QString();
+    }
+    return job.textData();
+}
+
+void SecretStore::write(const QString &key, const QString &secret)
+{
+    auto *job = new WritePasswordJob(service());
+    job->setAutoDelete(true);
+    job->setKey(key);
+    job->setTextData(secret);
+    QObject::connect(job, &Job::finished, job, [key](Job *j) {
+        if (j->error())
+            qWarning() << "SecretStore::write(" << key << ") failed:" << j->errorString();
+    });
+    job->start();
+}
+
+void SecretStore::remove(const QString &key)
+{
+    auto *job = new DeletePasswordJob(service());
+    job->setAutoDelete(true);
+    job->setKey(key);
+    job->start();
+}
+
+/* ************************************************************************** */

--- a/src/utils/SecretStore.h
+++ b/src/utils/SecretStore.h
@@ -1,0 +1,55 @@
+/*
+    Theengs - Decode things and devices
+    Copyright: (c) Florian ROBERT
+
+    This file is part of Theengs.
+
+    Theengs is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    Theengs is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef SECRET_STORE_H
+#define SECRET_STORE_H
+/* ************************************************************************** */
+
+#include <QString>
+
+/*!
+ * \brief Thin wrapper over QtKeychain for storing secrets in the OS secure store.
+ *
+ * Backends (provided by QtKeychain): Keychain on macOS/iOS, Credential Store on
+ * Windows, libsecret/KWallet on Linux, Android Keystore on Android. QtKeychain
+ * refuses to fall back to plaintext unless setInsecureFallback(true) is set, which
+ * we deliberately never do.
+ *
+ * Reads are synchronous (spinning a local QEventLoop) because credentials must be
+ * resolved before the first MQTT/MySQL connection attempt at startup, which happens
+ * before the main Qt event loop is entered. Writes/removes are fire-and-forget.
+ *
+ * Only compiled when ENABLE_SECURE_STORAGE is defined.
+ */
+namespace SecretStore
+{
+    //! Service name namespacing all Theengs secrets in the OS store.
+    QString service();
+
+    //! Blocking read. Returns an empty string if the key is absent or on error.
+    QString readSync(const QString &key);
+
+    //! Asynchronous, best-effort write.
+    void write(const QString &key, const QString &secret);
+
+    //! Asynchronous, best-effort delete.
+    void remove(const QString &key);
+}
+
+/* ************************************************************************** */
+#endif // SECRET_STORE_H


### PR DESCRIPTION
## Description:
Secure credential storage: move MQTT/MySQL passwords to the OS keychain
Passwords were persisted in plaintext via QSettings, and the app shipped
default credentials (theengs/theengs).

- Add QtKeychain as a bundled submodule (pinned 0.15.0; 0.14.0 fails to
  build on Qt 6.8+ Android) plus a small SecretStore wrapper that stores
  secrets in the OS secure store (Keychain on Apple, Credential Store on
  Windows, libsecret/KWallet on Linux, Android Keystore on Android).
- Rework SettingsManager so MQTT/MySQL passwords never touch QSettings,
  with a one-time migration of any legacy plaintext value into the keychain.
- Drop the shipped default credentials (now empty == not configured).
- Gate behind ENABLE_SECURE_STORAGE (default ON).

Validated on Android (LG H930, Samsung SM-G970U): build, install, launch,
plaintext -> Android Keystore migration, and keychain round-trip read; the
legacy plaintext password is removed from all app data files.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/app/blob/development/docs/participate/development.md#developer-certificate-of-origin).
