### PR TITLE
Background scanning: honour "Update interval" as the Android scan cadence

### DIFF
--- a/qml/Settings.qml
+++ b/qml/Settings.qml
@@ -520,7 +520,7 @@ Item {
 
                 visible: (Qt.platform.os === "android") // && (settingsManager.systray && element_worker.visible)
 
-                text: qsTr("Theengs keeps scanning for sensors when the app is closed, and refreshes their values on a regular interval. An ongoing notification appears while scanning — tap <b>Stop</b> there to turn it off at any time. Requires Bluetooth to be on.")
+                text: qsTr("Theengs keeps scanning for sensors when the app is closed, and refreshes their values at the interval set below. An ongoing notification appears while scanning — tap <b>Stop</b> there to turn it off at any time. Requires Bluetooth to be on.")
                 textFormat: Text.StyledText
                 wrapMode: Text.WordWrap
                 color: Theme.colorSubText
@@ -537,7 +537,7 @@ Item {
 
                 visible: isDesktop // && (settingsManager.systray && element_worker.visible)
 
-                text: (Qt.platform.os !== "osx") ? qsTr("Theengs will remain active in the system tray, and will wake up at a regular interval to refresh sensor data.") : qsTr("Theengs will refresh sensor data at a regular interval.")
+                text: (Qt.platform.os !== "osx") ? qsTr("Theengs stays active in the system tray and keeps refreshing sensor data while running.") : qsTr("Theengs keeps refreshing sensor data while running.")
                 textFormat: Text.PlainText
                 wrapMode: Text.WordWrap
                 color: Theme.colorSubText
@@ -554,8 +554,10 @@ Item {
                 anchors.right: parent.right
                 anchors.rightMargin: screenPaddingRight
 
-                // every platforms except iOS
-                visible: (Qt.platform.os !== "ios")
+                // Android only: the interval drives the background scan cadence
+                // (AndroidService work timer). Desktop scans continuously while
+                // in the system tray and ignores this value, so it is hidden there.
+                visible: (Qt.platform.os === "android")
 
                 IconSvg {
                     id: image_update_background

--- a/src/DeviceManager.cpp
+++ b/src/DeviceManager.cpp
@@ -920,7 +920,14 @@ void DeviceManager::deviceDiscoveryFinished()
     // devices) — see DeviceManager_advertisement.cpp:91-237.
     scanDevices_start();
 #else
-    listenDevices_start();
+    // In the Android background service (daemon mode), do NOT self-restart the
+    // listen loop. AndroidService::gotowork() starts one listen window every
+    // updateIntervalBackground minutes (via refreshDevices_background), so the
+    // radio idles between windows and the user's "Update interval" setting
+    // actually governs the background scan cadence. The foreground UI manager
+    // (m_daemonMode == false, on both mobile and desktop) keeps re-arming for
+    // a responsive live view / continuous system-tray scanning.
+    if (!m_daemonMode) listenDevices_start();
 #endif
 }
 


### PR DESCRIPTION
## Description:
The background "Update interval" setting (updateIntervalBackground, 5-360 min) was exposed in the UI as if it governed how often sensor values refresh, but it only drove the AndroidService work-timer's DeviceManager rebuild + MQTT reconnect. Actual background scanning ran on a self-restarting 60s listen loop (deviceDiscoveryFinished -> listenDevices_start), so the setting had no effect on scan/publish frequency (device-measured: continuous ~60s regardless).

Make the setting real on Android: in the background service (daemon mode) stop self-restarting the listen loop; AndroidService::gotowork() already fires every updateIntervalBackground minutes and starts one ~60s listen window, so the radio now idles between windows. The foreground UI manager (m_daemonMode == false, on mobile and desktop) keeps re-arming, so the live view and continuous system-tray scanning are unchanged. HIL_BENCH_MODE keeps its continuous active scan.

Desktop never reads this value (it scans continuously on mains power), so hide the interval picker on desktop and reword the desktop legend to stop implying an interval.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/app/blob/development/docs/participate/development.md#developer-certificate-of-origin).
