### PR TITLE
fix(device_bm26): guard mbedTLS AES block with ENABLE_MBEDTLS

### DIFF
--- a/src/devices/device_bm26.cpp
+++ b/src/devices/device_bm26.cpp
@@ -181,14 +181,16 @@ void DeviceTheengsBM26::serviceDetailsDiscovered_volt(QLowEnergyService::Service
 
                 const uint8_t data[16] = { 0xd1, 0x55, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00,
                                            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
-                uint8_t output[16];
+                uint8_t output[16] = {};
                 uint8_t iv[16] = { };
 
+#if defined(ENABLE_MBEDTLS)
                 mbedtls_aes_context aes;
                 mbedtls_aes_init(&aes);
                 mbedtls_aes_setkey_enc(&aes, m_key_bm6, 128);
                 mbedtls_aes_crypt_cbc(&aes, MBEDTLS_AES_ENCRYPT, 16, iv, data, output);
                 mbedtls_aes_free(&aes);
+#endif
 
                 // Characteristic "write"
                 m_charWrite = m_serviceVolt->characteristic(uuid_volt_char_write);


### PR DESCRIPTION

## Description:
The rest of device_bm26.cpp already gates mbedtls.h includes and uses on ENABLE_MBEDTLS, but the AES-CBC block inside
serviceDetailsDiscovered_volt() referenced mbedtls_aes_* unconditionally, breaking compilation with -DENABLE_MBEDTLS=OFF. Wrap the block in the same guard and zero-init the output buffer so the code path is well defined when the encryption helper is compiled out.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/app/blob/development/docs/participate/development.md#developer-certificate-of-origin).
