### PR TITLE
ci: bump actions to Node.js 24 runtimes

### DIFF
--- a/.github/workflows/builds_desktop.yml
+++ b/.github/workflows/builds_desktop.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       # Checkout repository (and submodules)
       - name: Checkout repository (and submodules)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -77,7 +77,7 @@ jobs:
 
       # Upload AppImage
       - name: Upload AppImage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ env.APP_NAME }}-${{ env.APP_VERSION }}-linux64.AppImage
           path: ${{ env.APP_NAME }}-${{ env.APP_VERSION }}-linux64.AppImage
@@ -90,7 +90,7 @@ jobs:
     steps:
       # Checkout repository (and submodules)
       - name: Checkout repository (and submodules)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -158,7 +158,7 @@ jobs:
 
       # Upload application bundle
       - name: Upload application bundle
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ env.APP_NAME }}-${{ env.APP_VERSION }}-macOS.zip
           path: ${{ env.APP_NAME }}-${{ env.APP_VERSION }}-macOS.zip
@@ -171,7 +171,7 @@ jobs:
     steps:
       # Checkout repository (and submodules)
       - name: Checkout repository (and submodules)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -226,7 +226,7 @@ jobs:
 
       # Upload application ZIP
       - name: Upload application ZIP
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ env.APP_NAME }}-${{ env.APP_VERSION }}-win64.zip
           path: ${{ env.APP_NAME }}-${{ env.APP_VERSION }}-win64.zip
@@ -234,7 +234,7 @@ jobs:
 
       # Upload NSIS installer
       - name: Upload NSIS installer
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ env.APP_NAME }}-${{ env.APP_VERSION }}-win64.exe
           path: ${{ env.APP_NAME }}-${{ env.APP_VERSION }}-win64.exe

--- a/.github/workflows/builds_mobile.yml
+++ b/.github/workflows/builds_mobile.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       # Checkout repository (and submodules)
       - name: Checkout repository (and submodules)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -49,7 +49,7 @@ jobs:
 
       # Android environment
       - name: Setup Android environment
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@v4
       - name: Install Android SDK / NDK / tools
         run: |
              sdkmanager "platforms;android-36"
@@ -284,7 +284,7 @@ jobs:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: com.theengs.app
           releaseFiles: build/android-build/build/outputs/bundle/release/*.aab
-          track: internal
+          tracks: internal
           status: completed
           whatsNewDirectory: distribution/whatsnew
 
@@ -301,7 +301,7 @@ jobs:
     steps:
       # Checkout repository (and submodules)
       - name: Checkout repository (and submodules)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -361,7 +361,7 @@ jobs:
       # Import App Store distribution signing certificate
       - name: Import signing certificate
         if: env.DISTRIBUTE == 'true'
-        uses: apple-actions/import-codesign-certs@v3
+        uses: apple-actions/import-codesign-certs@v7
         with:
           p12-file-base64: ${{ secrets.APPLE_DIST_CERT_P12_BASE64 }}
           p12-password: ${{ secrets.APPLE_DIST_CERT_PASSWORD }}
@@ -370,7 +370,7 @@ jobs:
       - name: Download provisioning profile
         if: env.DISTRIBUTE == 'true'
         id: provisioning
-        uses: apple-actions/download-provisioning-profiles@v4
+        uses: apple-actions/download-provisioning-profiles@v6
         with:
           bundle-id: com.theengs.app
           profile-type: IOS_APP_STORE
@@ -467,7 +467,7 @@ jobs:
 
       - name: Upload to TestFlight
         if: env.DISTRIBUTE == 'true'
-        uses: apple-actions/upload-testflight-build@v3
+        uses: apple-actions/upload-testflight-build@v5
         with:
           app-path: build/ipa/Theengs.ipa
           issuer-id: ${{ secrets.APPSTORE_ISSUER_ID }}

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Create the documentation and deploy it to GitHub Pages
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20.x"
       - name: Install build dependencies
@@ -18,7 +18,7 @@ jobs:
       - name: Build documentation
         run: npm run docs:build
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/.vitepress/dist


### PR DESCRIPTION
Pre-empts GitHub's June 2026 forced Node 24 migration and clears the deprecation warnings on the mobile and docs workflows:

- actions/checkout v4 -> v5
- actions/setup-node v4 -> v5
- actions/upload-artifact v4 -> v6
- android-actions/setup-android v3 -> v4
- apple-actions/import-codesign-certs v3 -> v7
- apple-actions/download-provisioning-profiles v4 -> v6
- apple-actions/upload-testflight-build v3 -> v5
- peaceiris/actions-gh-pages v3 -> v4

Also migrate r0adkll/upload-google-play from the deprecated 'track' input to the new 'tracks' input (semantically equivalent for our single-track Internal Testing upload).

ilammy/msvc-dev-cmd and jurplel/install-qt-action have no node24 release available yet; left pinned at v1 / v4 respectively.

## Description:


## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/app/blob/development/docs/participate/development.md#developer-certificate-of-origin).
