### PR TITLE
fix(ios): force mbedtls subtree static to avoid broken dylib rpaths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -306,6 +306,12 @@ if(ENABLE_MBEDTLS)
     set(ENABLE_TESTING OFF CACHE BOOL "" FORCE)
     set(ENABLE_PROGRAMS OFF CACHE BOOL "" FORCE)
     set(MBEDTLS_FATAL_WARNINGS OFF CACHE BOOL "" FORCE)
+    # Force static for mbedtls and its 3rdparty deps (everest, p256m). On iOS the
+    # Qt toolchain leaves BUILD_SHARED_LIBS=ON, which produces dylibs with absolute
+    # build-tree install paths; the resulting .app then fails to load at runtime
+    # because LC_RPATH only contains the build-machine paths, not
+    # @executable_path/Frameworks.
+    set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
     add_subdirectory(thirdparty/mbedtls)
     target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE MbedTLS::mbedtls)
     target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE ENABLE_MBEDTLS)


### PR DESCRIPTION
## Description:
On iOS the Qt toolchain leaves BUILD_SHARED_LIBS=ON, so mbedtls's 3rdparty deps (everest, p256m) build as dylibs whose install_name is @rpath/... but the main Theengs binary's LC_RPATH only points at absolute build-machine paths under build-ios-dev/. The .app installs fine but dyld then fails at launch with "Library not loaded: @rpath/libeverest.dylib".

Scope BUILD_SHARED_LIBS=OFF to the mbedtls add_subdirectory call so the sub-libraries are statically linked into the executable, mirroring the existing QTKEYCHAIN_STATIC pattern a few lines below.


## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/app/blob/development/docs/participate/development.md#developer-certificate-of-origin).
