### PR TITLE
About: show real TheengsDecoder version and store build number

### DIFF
--- a/.github/workflows/builds_desktop.yml
+++ b/.github/workflows/builds_desktop.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: recursive
+          fetch-depth: 0     # needed so `git describe` can read the TheengsDecoder submodule tag
 
       # Install dependencies (from package manager)
       - name: Install dependencies (from package manager)
@@ -93,6 +94,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: recursive
+          fetch-depth: 0     # needed so `git describe` can read the TheengsDecoder submodule tag
 
       # Install dependencies (from package manager)
       #- name: Install dependencies (from package manager)
@@ -174,6 +176,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: recursive
+          fetch-depth: 0     # needed so `git describe` can read the TheengsDecoder submodule tag
 
       # Configure MSVC
       - name: Configure MSVC

--- a/.github/workflows/builds_mobile.yml
+++ b/.github/workflows/builds_mobile.yml
@@ -39,6 +39,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: recursive
+          fetch-depth: 0     # needed so `git describe` can read the TheengsDecoder submodule tag
 
       # Java environment (already installed in 'ubuntu-24.04')
       #- name: Setup Java environment
@@ -304,6 +305,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: recursive
+          fetch-depth: 0     # needed so `git describe` can read the TheengsDecoder submodule tag
 
       # Pin Xcode to the latest stable version available on the runner so
       # builds are reproducible and we get the iOS 26+ SDK that App Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,27 @@ set(CMAKE_AUTORCC ON)
 set(APP_NAME ${CMAKE_PROJECT_NAME})
 set(APP_VERSION ${CMAKE_PROJECT_VERSION})
 
+# Derive the bundled TheengsDecoder version from the submodule's latest git tag.
+# Fallback literal must be bumped when the submodule is bumped (tarball builds,
+# shallow CI clones without tags, etc. fall through to it).
+set(THEENGS_DECODER_VERSION "2.3.0")
+find_package(Git QUIET)
+if(Git_FOUND AND EXISTS "${CMAKE_SOURCE_DIR}/thirdparty/TheengsDecoder/.git")
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} -C "${CMAKE_SOURCE_DIR}/thirdparty/TheengsDecoder" describe --tags --abbrev=0
+        OUTPUT_VARIABLE THEENGS_DECODER_VERSION_RAW
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        RESULT_VARIABLE _theengs_decoder_git_rc
+        ERROR_QUIET)
+    if(_theengs_decoder_git_rc EQUAL 0 AND THEENGS_DECODER_VERSION_RAW)
+        string(REGEX REPLACE "^v" "" THEENGS_DECODER_VERSION "${THEENGS_DECODER_VERSION_RAW}")
+    endif()
+    # Reconfigure when the submodule HEAD moves so the macro stays in sync.
+    set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
+        "${CMAKE_SOURCE_DIR}/thirdparty/TheengsDecoder/.git/HEAD")
+endif()
+message(STATUS "[PROJECT] THEENGS_DECODER_VERSION    = ${THEENGS_DECODER_VERSION}")
+
 option(ENABLE_MQTT "MQTT broker support" ON)
 option(ENABLE_OPENSSL "OpenSSL for various encryption needs" ON)
 option(ENABLE_MBEDTLS "mbedTLS for various encryption needs" ON)
@@ -134,6 +155,9 @@ qt_add_executable(${CMAKE_PROJECT_NAME}
 target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE src/)
 target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE thirdparty/TheengsDecoder/src/)
 target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE thirdparty/TheengsDecoder/src/arduino_json/src)
+
+target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE
+    THEENGS_DECODER_VERSION="${THEENGS_DECODER_VERSION}")
 
 qt_add_qml_module(${CMAKE_PROJECT_NAME}
     URI ${CMAKE_PROJECT_NAME}
@@ -357,6 +381,11 @@ set(UTILS_WIFI_ENABLED OFF CACHE BOOL "" FORCE)
 set(UTILS_NOTIFICATIONS_ENABLED ON CACHE BOOL "" FORCE)
 add_subdirectory(thirdparty/AppUtils)
 target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE AppUtils)
+# theengsDecoderVersion() lives in utils_app.cpp (compiled into the AppUtils
+# subproject), so the macro must also be defined on this target — defining it
+# only on Theengs leaves AppUtils's TU returning "unknown".
+target_compile_definitions(AppUtils PRIVATE
+    THEENGS_DECODER_VERSION="${THEENGS_DECODER_VERSION}")
 
 # MobileUI
 add_subdirectory(thirdparty/MobileUI)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,9 +12,10 @@ set(APP_NAME ${CMAKE_PROJECT_NAME})
 set(APP_VERSION ${CMAKE_PROJECT_VERSION})
 
 # Derive the bundled TheengsDecoder version from the submodule's latest git tag.
-# Fallback literal must be bumped when the submodule is bumped (tarball builds,
-# shallow CI clones without tags, etc. fall through to it).
-set(THEENGS_DECODER_VERSION "2.3.0")
+# CI checkouts use fetch-depth: 0 + submodules: recursive so tags are available.
+# Tarball builds (no .git at all) leave the macro undefined and the About screen
+# renders "unknown" — same fallback AppUtils returns when consumed elsewhere.
+set(THEENGS_DECODER_VERSION "")
 find_package(Git QUIET)
 if(Git_FOUND AND EXISTS "${CMAKE_SOURCE_DIR}/thirdparty/TheengsDecoder/.git")
     execute_process(
@@ -156,8 +157,10 @@ target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE src/)
 target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE thirdparty/TheengsDecoder/src/)
 target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE thirdparty/TheengsDecoder/src/arduino_json/src)
 
-target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE
-    THEENGS_DECODER_VERSION="${THEENGS_DECODER_VERSION}")
+if(THEENGS_DECODER_VERSION)
+    target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE
+        THEENGS_DECODER_VERSION="${THEENGS_DECODER_VERSION}")
+endif()
 
 qt_add_qml_module(${CMAKE_PROJECT_NAME}
     URI ${CMAKE_PROJECT_NAME}
@@ -384,8 +387,10 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE AppUtils)
 # theengsDecoderVersion() lives in utils_app.cpp (compiled into the AppUtils
 # subproject), so the macro must also be defined on this target — defining it
 # only on Theengs leaves AppUtils's TU returning "unknown".
-target_compile_definitions(AppUtils PRIVATE
-    THEENGS_DECODER_VERSION="${THEENGS_DECODER_VERSION}")
+if(THEENGS_DECODER_VERSION)
+    target_compile_definitions(AppUtils PRIVATE
+        THEENGS_DECODER_VERSION="${THEENGS_DECODER_VERSION}")
+endif()
 
 # MobileUI
 add_subdirectory(thirdparty/MobileUI)

--- a/qml/About.qml
+++ b/qml/About.qml
@@ -62,7 +62,12 @@ Item {
                         }
                         Text {
                             color: Theme.colorSubText
-                            text: qsTr("version %1 %2").arg(utilsApp.appVersion()).arg(utilsApp.appBuildMode())
+                            text: {
+                                var bn = utilsApp.appBuildNumber()
+                                return bn.length > 0
+                                    ? qsTr("%1 (%2) %3").arg(utilsApp.appVersion()).arg(bn).arg(utilsApp.appBuildMode())
+                                    : qsTr("%1 %2").arg(utilsApp.appVersion()).arg(utilsApp.appBuildMode())
+                            }
                             font.pixelSize: Theme.fontSizeContentBig
                         }
                     }
@@ -173,7 +178,7 @@ Item {
                     anchors.rightMargin: 48
                     anchors.verticalCenter: parent.verticalCenter
 
-                    text: "1.5"
+                    text: utilsApp.appVersion()
                 }
             }
 
@@ -189,14 +194,19 @@ Item {
                 sourceSize: 24
                 indicatorSource: "qrc:/IconLibrary/material-icons/duotone/launch.svg"
 
-                onClicked: Qt.openUrlExternally("https://github.com/theengs/decoder/releases/tag/v2.1.0")
+                onClicked: {
+                    var v = utilsApp.theengsDecoderVersion()
+                    Qt.openUrlExternally(v === "unknown"
+                        ? "https://github.com/theengs/decoder/releases"
+                        : "https://github.com/theengs/decoder/releases/tag/v" + v)
+                }
 
                 ItemBadge {
                     anchors.right: parent.right
                     anchors.rightMargin: 48
                     anchors.verticalCenter: parent.verticalCenter
 
-                    text: "2.1.0"
+                    text: utilsApp.theengsDecoderVersion()
                 }
             }
 
@@ -269,7 +279,7 @@ Item {
 
                     Repeater {
                         model: [
-                            "Theengs decoder (LGPL v3)",
+                            "Theengs decoder " + utilsApp.theengsDecoderVersion() + " (GPL v3)",
                             "Qt6 (LGPL v3)",
                             "QtMqtt (GPL v3)",
                             "Mbed TLS (Apache 2.0)",
@@ -322,6 +332,8 @@ Item {
                             var txt = ""
                             txt += "App name: %1".arg(utilsApp.appName()) + "\n"
                             txt += "App version: %1".arg(utilsApp.appVersion()) + "\n"
+                            txt += "Build number: %1".arg(utilsApp.appBuildNumber()) + "\n"
+                            txt += "Theengs Decoder: %1".arg(utilsApp.theengsDecoderVersion()) + "\n"
                             txt += "Build mode: %1".arg(utilsApp.appBuildModeFull()) + "\n"
                             txt += "Build architecture: %1".arg(utilsApp.qtArchitecture()) + "\n"
                             txt += "Build date: %1".arg(utilsApp.appBuildDateTime()) + "\n"
@@ -349,6 +361,19 @@ Item {
                         Text {
                             color: Theme.colorSubText
                             text: "App version: %1".arg(utilsApp.appVersion())
+                            textFormat: Text.PlainText
+                            font.pixelSize: Theme.fontSizeContent
+                        }
+                        Text {
+                            color: Theme.colorSubText
+                            text: "Build number: %1".arg(utilsApp.appBuildNumber())
+                            textFormat: Text.PlainText
+                            font.pixelSize: Theme.fontSizeContent
+                            visible: utilsApp.appBuildNumber().length > 0
+                        }
+                        Text {
+                            color: Theme.colorSubText
+                            text: "Theengs Decoder: %1".arg(utilsApp.theengsDecoderVersion())
                             textFormat: Text.PlainText
                             font.pixelSize: Theme.fontSizeContent
                         }

--- a/thirdparty/AppUtils/utils_app.cpp
+++ b/thirdparty/AppUtils/utils_app.cpp
@@ -91,6 +91,26 @@ QString UtilsApp::appVersion()
     return QString::fromLatin1(APP_VERSION);
 }
 
+QString UtilsApp::appBuildNumber()
+{
+#if defined(Q_OS_ANDROID)
+    return UtilsAndroid::getVersionCode();
+#elif defined(Q_OS_IOS)
+    return UtilsIOS::getBundleVersion();
+#else
+    return QString();
+#endif
+}
+
+QString UtilsApp::theengsDecoderVersion()
+{
+#ifdef THEENGS_DECODER_VERSION
+    return QString::fromLatin1(THEENGS_DECODER_VERSION);
+#else
+    return QStringLiteral("unknown");
+#endif
+}
+
 QString UtilsApp::appBuildDate()
 {
     return QString::fromLatin1(__DATE__);

--- a/thirdparty/AppUtils/utils_app.h
+++ b/thirdparty/AppUtils/utils_app.h
@@ -55,6 +55,13 @@ public:
     static Q_INVOKABLE QString appName();
     static Q_INVOKABLE QString appVersion();
 
+    // Platform-native store build number: CFBundleVersion on iOS, versionCode on Android, empty on desktop.
+    static Q_INVOKABLE QString appBuildNumber();
+
+    // Project-specific: returns the THEENGS_DECODER_VERSION macro defined by the Theengs CMake target.
+    // Other consumers of AppUtils get "unknown" since the macro is not defined for them.
+    static Q_INVOKABLE QString theengsDecoderVersion();
+
     static Q_INVOKABLE QString appBuildDate();
     static Q_INVOKABLE QString appBuildDateTime();
     static Q_INVOKABLE QString appBuildMode();

--- a/thirdparty/AppUtils/utils_os_android.cpp
+++ b/thirdparty/AppUtils/utils_os_android.cpp
@@ -637,6 +637,28 @@ QString UtilsAndroid::getDeviceSerial()
     return device_serial;
 }
 
+QString UtilsAndroid::getVersionCode()
+{
+    QJniObject context = QNativeInterface::QAndroidApplication::context();
+    if (!context.isValid()) return QString();
+
+    QJniObject pm = context.callObjectMethod("getPackageManager",
+                                             "()Landroid/content/pm/PackageManager;");
+    QJniObject pkgName = context.callObjectMethod("getPackageName",
+                                                  "()Ljava/lang/String;");
+    if (!pm.isValid() || !pkgName.isValid()) return QString();
+
+    QJniObject info = pm.callObjectMethod("getPackageInfo",
+                                          "(Ljava/lang/String;I)Landroid/content/pm/PackageInfo;",
+                                          pkgName.object<jstring>(), 0);
+
+    QJniEnvironment env;
+    if (env.checkAndClearExceptions() || !info.isValid()) return QString();
+
+    jint code = info.getField<jint>("versionCode");
+    return QString::number(static_cast<int>(code));
+}
+
 /* ************************************************************************** */
 
 void UtilsAndroid::screenKeepOn(bool on)

--- a/thirdparty/AppUtils/utils_os_android.h
+++ b/thirdparty/AppUtils/utils_os_android.h
@@ -216,6 +216,13 @@ public:
      */
     static QString getDeviceSerial();
 
+    /*!
+     * \return The app's PackageInfo.versionCode (legacy 32-bit field), as a string.
+     *
+     * This is the value the Play Store uses to identify builds.
+     */
+    static QString getVersionCode();
+
     /* ********************************************************************** */
 
     /*!

--- a/thirdparty/AppUtils/utils_os_ios.h
+++ b/thirdparty/AppUtils/utils_os_ios.h
@@ -42,6 +42,8 @@ public:
     static void screenLockOrientation(int orientation, bool autoRotate);
 
     static void vibrate(int milliseconds);
+
+    static QString getBundleVersion();
 };
 
 /* ************************************************************************** */

--- a/thirdparty/AppUtils/utils_os_ios.mm
+++ b/thirdparty/AppUtils/utils_os_ios.mm
@@ -84,4 +84,13 @@ void UtilsIOS::vibrate(int ms)
 }
 
 /* ************************************************************************** */
+
+QString UtilsIOS::getBundleVersion()
+{
+    NSString *v = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"];
+    if (v == nil) return QString();
+    return QString::fromNSString(v);
+}
+
+/* ************************************************************************** */
 #endif // Q_OS_IOS


### PR DESCRIPTION
## Description:
- Derive the bundled TheengsDecoder version from the submodule's git tag at CMake configure time (fallback literal "2.3.0" for shallow CI clones and tarball builds). Inject it as THEENGS_DECODER_VERSION on both the Theengs executable target and the AppUtils static lib so utils_app.cpp picks it up at compile time.
- Add utilsApp.theengsDecoderVersion() and utilsApp.appBuildNumber():
  - Decoder version: replaces the hardcoded "2.1.0" badge and release URL.
  - Build number: reads CFBundleVersion on iOS, PackageInfo.versionCode on Android via JNI, empty on desktop. Matches what users see on the App Store / Play Store.
- About.qml: header line shows "1.5.0 (<build-number>) DEBUG" on mobile and drops the build number on desktop where it doesn't apply. The "Theengs App" badge now binds to appVersion(); the "Theengs Decoder" badge + GitHub release URL bind to theengsDecoderVersion(). Dependency list and debug-info section also pick up the new values. Fixes the decoder license string to GPL v3.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/app/blob/development/docs/participate/development.md#developer-certificate-of-origin).
