### PR TITLE
docs(devices): flag SwitchBot controllable and BM2/BM6 on-demand connect

### DIFF
--- a/docs/prerequisites/devices.md
+++ b/docs/prerequisites/devices.md
@@ -9,77 +9,82 @@ Here is the list of supported devices by the app, more details in the Compatible
 Since Theengs Decoder v2.1.0 some `model_id` strings are consolidated when several products share an advertisement format — for example `H5072` and `H5075` are reported as `H5072/75`, and `IBT-6XS` / `SOLIS-6` as `IBT-6XS/SOLIS-6`. Both legacy and merged IDs continue to be recognised by the app; the table below keeps the legacy names for searchability.
 :::
 
-|Model_Id|Mobile App|
-|-|-|
-|ABTemp|✅|
-|ADHS|✅|
-|TD1in1|✅|
-|TD3in1|✅|
-|TD4in1|✅|
-|BSDOO|✅|
-|CGC1|✅|
-|CGD1|✅|
-|CGDK2|✅|
-|CGDN1|✅|
-|CGG1|✅|
-|CGH1|✅|
-|CGP1W|✅|
-|CGPR1|✅|
-|F525|✅|
-|BM2|✅|
-|BM6|✅|
-|H5055|✅|
-|H5072|✅|
-|H5074|✅|
-|H5075|✅|
-|H5106|✅|
-|H5101|✅|
-|H5102|✅|
-|H5174|✅|
-|H5177|✅|
-|HHCCJCY01HHCC|✅|
-|HHCCJCY10|✅|
-|HHCCPOT002|✅|
-|IBS-TH1|✅|
-|IBS-TH2|✅|
-|IBS-P01B|✅|
-|IBT_2X(S)|✅|
-|IBT_4X(S/C)|✅|
-|IBT_6X(S)|✅|
-|JQJCY01YM|✅|
-|K6P|✅|
-|K9|✅|
-|LYWSD02|✅|
-|LYWSD03MMC_ATC/PVVX|✅|
-|MJWSD05MMC_ATC/PVVX|✅|
-|LYWSDCGQ|✅|
-|MBXPRO|✅|
-|MHO/MMC-C401_ATC/PVVX|✅|
-|MokoBeacon|✅|
-|M1017|✅|
-|RDL52832|✅|
-|RuuviTag_RAWv1|✅|
-|RuuviTag_RAWv2|✅|
-|SBBT (W270160X)|✅|
-|SBCU (W070160X)|✅|
-|SBS1 (X1)|✅|
-|W120150X|✅|
-|W110150X|✅|
-|THX1(W230150X)|✅|
-|SDLS|✅|
-|SE_MAG|✅|
-|SE_RHT|✅|
-|SE_TEMP|✅|
-|SE_TPROBE|✅|
-|SHT4X|✅|
-|SOLIS_6|✅|
-|T201|✅|
-|T301|✅|
-|WS02/WS08|✅|
-|TP357|✅|
-|TP358|✅|
-|TP359|✅|
-|TP393|✅|
-|TPMS|✅|
-|XMTZC01HM/XMTZC04HM|✅|
-|XMTZC02HM/XMTZC05HM|✅|
+The **Notes** column flags devices that do more than passive advertisement reading:
+
+- 🎛️ **Controllable** — the app opens a BLE link on demand to send a control action, then releases it.
+- 🔌 **On-demand connect** — the app opens a BLE link on demand to read values that aren't advertised (e.g. battery voltage).
+
+|Model_Id|Mobile App|Notes|
+|-|-|-|
+|ABTemp|✅||
+|ADHS|✅||
+|TD1in1|✅||
+|TD3in1|✅||
+|TD4in1|✅||
+|BSDOO|✅||
+|CGC1|✅||
+|CGD1|✅||
+|CGDK2|✅||
+|CGDN1|✅||
+|CGG1|✅||
+|CGH1|✅||
+|CGP1W|✅||
+|CGPR1|✅||
+|F525|✅||
+|BM2|✅|🔌 On-demand connect (battery monitor)|
+|BM6|✅|🔌 On-demand connect (battery monitor)|
+|H5055|✅||
+|H5072|✅||
+|H5074|✅||
+|H5075|✅||
+|H5106|✅||
+|H5101|✅||
+|H5102|✅||
+|H5174|✅||
+|H5177|✅||
+|HHCCJCY01HHCC|✅||
+|HHCCJCY10|✅||
+|HHCCPOT002|✅||
+|IBS-TH1|✅||
+|IBS-TH2|✅||
+|IBS-P01B|✅||
+|IBT_2X(S)|✅||
+|IBT_4X(S/C)|✅||
+|IBT_6X(S)|✅||
+|JQJCY01YM|✅||
+|K6P|✅||
+|K9|✅||
+|LYWSD02|✅||
+|LYWSD03MMC_ATC/PVVX|✅||
+|MJWSD05MMC_ATC/PVVX|✅||
+|LYWSDCGQ|✅||
+|MBXPRO|✅||
+|MHO/MMC-C401_ATC/PVVX|✅||
+|MokoBeacon|✅||
+|M1017|✅||
+|RDL52832|✅||
+|RuuviTag_RAWv1|✅||
+|RuuviTag_RAWv2|✅||
+|SBBT (W270160X)|✅|🎛️ Controllable (Blind Tilt)|
+|SBCU (W070160X)|✅|🎛️ Controllable (Curtain 2/3)|
+|SBS1 (X1)|✅|🎛️ Controllable (Bot S1)|
+|W120150X|✅||
+|W110150X|✅||
+|THX1(W230150X)|✅||
+|SDLS|✅||
+|SE_MAG|✅||
+|SE_RHT|✅||
+|SE_TEMP|✅||
+|SE_TPROBE|✅||
+|SHT4X|✅||
+|SOLIS_6|✅||
+|T201|✅||
+|T301|✅||
+|WS02/WS08|✅||
+|TP357|✅||
+|TP358|✅||
+|TP359|✅||
+|TP393|✅||
+|TPMS|✅||
+|XMTZC01HM/XMTZC04HM|✅||
+|XMTZC02HM/XMTZC05HM|✅||


### PR DESCRIPTION
## Description:
Add a Notes column to the supported-devices table so users can tell at a glance which entries involve more than passive advertisement reading: the controllable SwitchBot actuators (SBBT, SBCU, SBS1) and the BM2/BM6 battery monitors that need an on-demand BLE connect to read voltage.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/app/blob/development/docs/participate/development.md#developer-certificate-of-origin).
