### PR TITLE
fix(android): force basic render loop to avoid EGL makeCurrent abort

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -109,6 +109,18 @@ int main(int argc, char *argv[])
     qputenv("QT_QUICK_FLICKABLE_WHEEL_DECELERATION", "2500");
 #endif
 
+#if defined(Q_OS_ANDROID)
+    // The threaded Qt Quick render loop (Android default) races the SurfaceView
+    // lifecycle on background/foreground transitions: when eglCreateWindowSurface
+    // fails mid-transition, QAndroidPlatformOpenGLWindow::ensureEglSurfaceCreated()
+    // calls qFatal() and the app aborts. Still unfixed upstream (QTBUG-142195;
+    // qFatal present in qtbase v6.10.3 / 6.10 / dev), so forcing the basic
+    // (GUI-thread) render loop serializes rendering with surface events and avoids
+    // the race. Respect an explicit override if the environment already sets it.
+    if (qEnvironmentVariableIsEmpty("QSG_RENDER_LOOP"))
+        qputenv("QSG_RENDER_LOOP", "basic");
+#endif
+
     // GUI application /////////////////////////////////////////////////////////
 
     SingleApplication app(argc, argv, true);


### PR DESCRIPTION
## Description:
On Android the threaded Qt Quick render loop races the SurfaceView lifecycle across background/foreground transitions. When eglCreateWindowSurface fails mid-transition,
QAndroidPlatformOpenGLWindow::ensureEglSurfaceCreated() calls qFatal() and the app aborts. Observed as 1.5.0 field crashes on Android 16, stack: QRhi::beginFrame -> QOpenGLContext::makeCurrent -> qtforandroid -> QMessageLogger::fatal -> abort.

The qFatal is still present upstream in qtbase v6.10.3, the 6.10 branch and dev (tracked loosely by the unresolved QTBUG-142195), so bumping Qt does not help. Forcing QSG_RENDER_LOOP=basic moves rendering onto the GUI thread, serialized with Android surface events, removing the race. An explicit QSG_RENDER_LOOP from the environment is still respected.


## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/app/blob/development/docs/participate/development.md#developer-certificate-of-origin).
