### PR TITLE
fix(android): _exit() the background service to avoid exit()/__cxa_finalize ART abort

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,6 +53,7 @@
 #include <QSurfaceFormat>
 
 #if defined(Q_OS_ANDROID)
+#include <unistd.h> // _exit()
 #include "AndroidService.h"
 #include "private/qandroidextras_p.h" // for QAndroidService
 #endif
@@ -93,12 +94,28 @@ int main(int argc, char *argv[])
         if (sm && sm->getSysTray())
         {
             AndroidService *as = new AndroidService();
-            if (!as) return EXIT_FAILURE;
+            if (!as) _exit(EXIT_FAILURE);
 
-            return app.exec();
+            const int rc = app.exec();
+            // Terminate this Qt-hosted service process with _exit() rather than
+            // a normal return (which calls exit()). On Android, exiting via
+            // exit() runs __cxa_finalize, which tears down the ART runtime and
+            // aborts ("destroying mutex with owner or contenders") whenever
+            // another runtime thread (JIT/GC/Binder/Qt) still holds a lock at
+            // teardown — a ~8% race per service exit, observed crashing the
+            // ":qt_service" process repeatedly in the field. _exit() ends the
+            // process via exit_group without running static destructors; the
+            // process is terminating regardless, so the skipped C++/Qt cleanup
+            // is moot.
+            _exit(rc);
         }
 
-        return EXIT_SUCCESS;
+        // Background updates disabled: this service has nothing to do. Same
+        // _exit() rationale as above — the service is frequently (re)spawned by
+        // the boot receiver / OS service-restart even when idle, so avoiding
+        // the exit()/__cxa_finalize ART-teardown abort here removes the bulk of
+        // the crashes.
+        _exit(EXIT_SUCCESS);
 #endif
     }
 


### PR DESCRIPTION

## Description:

The :qt_service (QtService-based BLE scan) process aborts ~8% of the time on exit with 'destroying mutex with owner or contenders': returning from the service main() calls exit(), which runs __cxa_finalize and tears down the ART runtime while other runtime threads (JIT/GC/Binder/Qt) still hold locks. The service is frequently (re)spawned by the boot receiver / OS service-restart, so this recurs in the field even when background updates are off.

Replace the service branch's returns with _exit(), which ends the process via exit_group without running static destructors. The process is terminating regardless, so skipped C++/Qt cleanup is moot.

Validated on a Pixel 8a (Android 15): 0 aborts in 108 service start/exit cycles, vs ~8% (3/39) on the unfixed build. Touches only the --service branch, so the GUI process is unaffected.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/app/blob/development/docs/participate/development.md#developer-certificate-of-origin).
