### PR TITLE
ci(desktop): stop uploading build artifacts on every run

### DIFF
--- a/.github/workflows/builds_desktop.yml
+++ b/.github/workflows/builds_desktop.yml
@@ -76,14 +76,6 @@ jobs:
       - name: Deploy application
         run: ./deploy_linux.sh -p
 
-      # Upload AppImage
-      - name: Upload AppImage
-        uses: actions/upload-artifact@v6
-        with:
-          name: ${{ env.APP_NAME }}-${{ env.APP_VERSION }}-linux64.AppImage
-          path: ${{ env.APP_NAME }}-${{ env.APP_VERSION }}-linux64.AppImage
-          retention-days: 7
-
   ## macOS build ###############################################################
   build-mac:
     name: "macOS CI build"
@@ -158,14 +150,6 @@ jobs:
           MACOS_CERTIFICATE_NAME: ${{ secrets.MACOS_CERTIFICATE_NAME }}
         run: ./deploy_macos.sh -c -p
 
-      # Upload application bundle
-      - name: Upload application bundle
-        uses: actions/upload-artifact@v6
-        with:
-          name: ${{ env.APP_NAME }}-${{ env.APP_VERSION }}-macOS.zip
-          path: ${{ env.APP_NAME }}-${{ env.APP_VERSION }}-macOS.zip
-          retention-days: 7
-
   ## Windows build #############################################################
   build-windows:
     name: "Windows CI build"
@@ -226,19 +210,3 @@ jobs:
       # Deploy application
       - name: Deploy application
         run: sh deploy_windows.sh -c -p
-
-      # Upload application ZIP
-      - name: Upload application ZIP
-        uses: actions/upload-artifact@v6
-        with:
-          name: ${{ env.APP_NAME }}-${{ env.APP_VERSION }}-win64.zip
-          path: ${{ env.APP_NAME }}-${{ env.APP_VERSION }}-win64.zip
-          retention-days: 7
-
-      # Upload NSIS installer
-      - name: Upload NSIS installer
-        uses: actions/upload-artifact@v6
-        with:
-          name: ${{ env.APP_NAME }}-${{ env.APP_VERSION }}-win64.exe
-          path: ${{ env.APP_NAME }}-${{ env.APP_VERSION }}-win64.exe
-          retention-days: 7


### PR DESCRIPTION
## Description:
The desktop CI (Linux/macOS/Windows) attached AppImage, macOS bundle, Windows ZIP and NSIS installer to every push/PR run. These piled up on each Actions run and aren't needed for CI verification. Drop the four upload-artifact steps; the jobs still build and run their deploy scripts as smoke tests.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/app/blob/development/docs/participate/development.md#developer-certificate-of-origin).
