### PR TITLE
fix(android): keep system back working on Android 16 (targetSdk 36)

### DIFF
--- a/assets/android/AndroidManifest.xml
+++ b/assets/android/AndroidManifest.xml
@@ -59,7 +59,8 @@
                  android:label="Theengs BLE"
                  android:allowBackup="true"
                  android:fullBackupContent="@xml/backup_rules"
-                 android:dataExtractionRules="@xml/data_extraction_rules">
+                 android:dataExtractionRules="@xml/data_extraction_rules"
+                 android:enableOnBackInvokedCallback="false">
 
         <!-- Activity -->
         <activity android:name="org.qtproject.qt.android.bindings.QtActivity"


### PR DESCRIPTION
## Description:
On Android 16 / targetSdk 36, android:enableOnBackInvokedCallback defaults to true, so the OS routes the back gesture and the 3-button back through OnBackInvokedDispatcher instead of dispatching KEYCODE_BACK. Qt does not register an OnBackInvokedCallback, so the platform's default callback finishes the activity and the app closes from any sub-screen, instead of navigating back via MobileApplication.qml's Keys.onBackPressed -> backAction().

Opt out of the predictive back callback to restore legacy KEYCODE_BACK delivery. Verified on a Pixel 8a (Android 16): edge-swipe and 3-button back now return to the previous screen; double-back-to-exit on the main screen still works.

Fixes #152

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/app/blob/development/docs/participate/development.md#developer-certificate-of-origin).
